### PR TITLE
Refactoring and new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+## Unreleased
+
+### New Features
+
+- **`lags()` formula term**: `@formula(y ~ lags(x, 12))` expands into a matrix of 12 lag columns. Supports nested transforms (`lags(log(abs(x)), 3)`), interactions (`lags(x, 3) & z`), and composition with other terms. Moved from LocalProjections.jl so both packages share the same implementation.
+
+- **`first_stage_F_iid(m)`**, **`first_stage_F_robust(m)`**, **`first_stage_F_KP(m)`**: New first-stage diagnostic API returning `FirstStageFTest{T, K}` — parametric on value type (`Float64` or `Vector{Float64}`) and variance estimator type. Replaces the ambiguous `first_stage(m)` / `first_stage_f(m)` functions.
+
+- **Kleibergen-Paap rk Wald F-statistic exposed**: The joint KP test statistic is now stored on the model and accessible via `first_stage_F_KP(m)`. Previously computed but discarded.
+
+- **`AbstractTest` type hierarchy**: `AbstractTest` is the new abstract supertype for `FirstStageFTest{T, K}` and `WeakIVTestResult{T}`.
+
+- **`Homoskedastic` type**: Sentinel type used as the variance estimator parameter for IID F-tests.
+
+- **NaN row filtering for `lags()`**: Rows with NaN values produced by `lags()` in the design matrix are automatically excluded from estimation in OLS, TSLS, and K-class models. The `esample` field correctly reflects these exclusions.
+
+- **EWC, DriscollKraay, VARHAC support**: All `Correlated` variance estimators from CovarianceMatrices.jl now work with `model + vcov(...)` (previously only `HAC` was supported).
+
+### Bug Fixes
+
+- **HC3 first-stage F-statistic**: The robust first-stage F with HC3 (and HC2/HC4/HC5) was silently using the HC1 formula. Refactored to delegate to CovarianceMatrices.jl, which handles all variance types correctly.
+
+- **`esample` with `lags()`**: `esample` now correctly marks NaN-filtered rows as `false`, so `sum(m.esample) == nobs(m)` and residuals can be mapped back to the original DataFrame via `res[m.esample] .= residuals(m)`.
+
+- **`lags()` with nested transforms and other terms**: `@formula(y ~ lags(log(abs(x)), 3) + log(x))` previously crashed because `StatsModels.terms(::LagTerm)` returned a `FunctionTerm` instead of leaf terms.
+
+- **`lags()` coefficient names for nested transforms**: `lags(log(abs(x)), 3)` produced names like `l_lag1` instead of `log(abs(x))_lag1`.
+
+- **`_compute_meat` cluster aggregation**: The Kleibergen-Paap rank test's cluster-robust meat computation treated a `Clustering` struct as a raw vector. Fixed to use `.groups` / `.ngroups`.
+
+- **Fixest validation F-stat references**: Test reference values for `F_nonrobust` were Kleibergen-Paap statistics, not IID F-statistics. Corrected to match the actual SSR-based F-test.
+
+- **`first_stage with vcov` test**: HC1 and HC3 first-stage robust F-statistics were identical due to the HC3 fallthrough bug.
+
+- **Fallback path in `compute_per_endogenous_fstats`**: The fallback when `Xendo_orig` is `nothing` passed `Z_res` as the full design matrix, producing wrong F-statistics. Replaced with an explicit error.
+
+### Refactoring
+
+- **First-stage robust F via CovarianceMatrices.jl**: Replaced ~250 lines of manual sandwich variance computation (`_compute_meat_inplace!`, `_compute_robust_first_stage_fstats_batched`, `_compute_single_first_stage_fstat`) with `_compute_first_stage_fstats_via_ols`, which constructs lightweight `OLSMatrixEstimator` wrappers around pre-computed first-stage data and delegates to `CovarianceMatrices.vcov`. No refitting; ZZ factorization is shared across endogenous variables.
+
+- **`_filter_nan_rows` shared utility**: Extracted the NaN-filtering logic (previously triplicated in `fit_ols.jl`, `tsls.jl`, `kclass.jl`) into a single function in `fit_common.jl`.
+
+- **`LagTerm` multi-column guard**: `modelcols(::LagTerm)` now throws `ArgumentError` for multi-column inner terms (interactions, categoricals) instead of producing silently wrong results.
+
+- **LocalProjections.jl integration**: `first_stage` and `weakivtest` in LocalProjections.jl now extend the Regress.jl functions instead of defining separate ones.
+
+- **Test import cleanup**: Replaced `using CovarianceMatrices: ...` with `using Regress: ...` in test files where CovarianceMatrices is not directly loadable. Eliminated `Base.==` method redefinition warnings in `test_formula.jl`.
+
+### Documentation
+
+- **`docs/src/iv_fstats.md`**: New document covering all IV diagnostics — IID F, robust Wald F, Kleibergen-Paap rank test, Montiel-Olea-Pflueger weak IV test, Wu-Hausman endogeneity test, and Sargan overidentification test — with exact formulas, computation steps, and API examples.

--- a/docs/src/iv_fstats.md
+++ b/docs/src/iv_fstats.md
@@ -1,0 +1,264 @@
+# IV First-Stage and Weak Instrument Diagnostics
+
+## Setup
+
+```julia
+using Regress
+m = iv(TSLS(), df, @formula(y ~ x1 + x2 + (endo ~ z1 + z2)))
+```
+
+---
+
+## 1. IID First-Stage F (`first_stage_f`)
+
+Standard F-test from the first-stage OLS under homoskedasticity. Equation-by-equation.
+
+**Notation.** Let $Z_{\text{full}} = [X_{\text{exo}},\; Z]$ be the $n \times (p + \ell)$ first-stage design matrix, where $X_{\text{exo}}$ is $n \times p$ (exogenous regressors including intercept) and $Z$ is $n \times \ell$ (excluded instruments). For the $j$-th endogenous variable $x_j$:
+
+**Computation.**
+
+1. Restricted regression (instruments excluded):
+$$\hat{e}^R_j = x_j - X_{\text{exo}}(X_{\text{exo}}'X_{\text{exo}})^{-1}X_{\text{exo}}'x_j, \qquad \text{SSR}_R = \hat{e}_j^{R\prime}\hat{e}_j^R$$
+
+2. Full regression (instruments included):
+$$\hat{e}^F_j = x_j - Z_{\text{full}}(Z_{\text{full}}'Z_{\text{full}})^{-1}Z_{\text{full}}'x_j, \qquad \text{SSR}_F = \hat{e}_j^{F\prime}\hat{e}_j^F$$
+
+3. F-statistic:
+$$F_j = \frac{(\text{SSR}_R - \text{SSR}_F)\;/\;\ell}{\text{SSR}_F\;/\;(n - p - \ell - d_{\text{fe}})}, \qquad p\text{-value from } F(\ell,\; n - p - \ell - d_{\text{fe}})$$
+
+**Access.**
+
+```julia
+fs = first_stage_f(m)
+fs.F_per_endo    # Vector, one F per endogenous variable
+fs.p_per_endo    # p-values
+fs.df1, fs.df2   # (ℓ, n − p − ℓ − d_fe)
+```
+
+---
+
+## 2. Robust First-Stage F (`first_stage`)
+
+Wald test of $H_0\!: \pi_j = 0$ in the first-stage OLS, with sandwich variance. Equation-by-equation.
+
+**Notation.** Same $Z_{\text{full}}$, $p$, $\ell$ as above. The first-stage OLS for endogenous variable $j$ is:
+
+$$x_j = Z_{\text{full}}\,\beta_j + e_j$$
+
+**Computation.**
+
+1. Coefficients (computed once for all $j$ via shared Cholesky):
+$$\hat{\beta}_j = (Z_{\text{full}}'Z_{\text{full}})^{-1}Z_{\text{full}}'x_j$$
+
+2. Fitted values and residuals:
+$$\hat{\mu}_j = Z_{\text{full}}\hat{\beta}_j, \qquad \hat{e}_j = x_j - \hat{\mu}_j$$
+
+3. Sandwich variance via CovarianceMatrices.jl — wraps $(\hat{e}_j, Z_{\text{full}}, \hat{\mu}_j)$ in a lightweight `OLSMatrixEstimator` and calls:
+$$V_j = \text{vcov}(\texttt{vcov\_type},\;\text{model}_j)$$
+   This handles HC0–HC5, CR0–CR3, HAC, EWC, etc.
+
+4. Extract the instrument-coefficient block and Wald test:
+$$V_{\pi_j} = V_j[p\!+\!1:p\!+\!\ell,\; p\!+\!1:p\!+\!\ell], \qquad \hat{\pi}_j = \hat{\beta}_j[p\!+\!1:p\!+\!\ell]$$
+
+$$F_j = \frac{\hat{\pi}_j'\,V_{\pi_j}^{-1}\,\hat{\pi}_j}{\ell}, \qquad p\text{-value from } F(\ell,\; n - p - \ell - d_{\text{fe}})$$
+
+**Access.**
+
+```julia
+fs = first_stage(m)
+fs.F_nonrobust   # IID F (same as first_stage_f)
+fs.F_robust      # Robust Wald F (uses model's vcov, default HC1)
+fs.vcov_type     # String name of vcov estimator
+
+# Switch variance estimator without refitting:
+m_hc3 = m + vcov(HC3())
+first_stage(m_hc3).F_robust     # recomputed with HC3
+first_stage(m_hc3).F_nonrobust  # unchanged
+```
+
+---
+
+## 3. Montiel-Olea & Pflueger Weak IV Test (`weakivtest`)
+
+Tests for weak instruments. Single endogenous regressor only. Returns three F-statistics and critical values.
+
+**Notation.** Let $n$ observations, $\ell$ excluded instruments, $p$ exogenous regressors.
+
+**Computation.**
+
+1. Partial out exogenous regressors via QR:
+$$\tilde{y} = M_{X_{\text{exo}}}\,y, \qquad \tilde{x} = M_{X_{\text{exo}}}\,x_{\text{endo}}$$
+   where $M_A = I - A(A'A)^{-1}A'$.
+
+2. Orthogonalize instruments: $Z_s = Q\sqrt{n}$ from $\text{QR}(M_{X_{\text{exo}}}Z)$, so $Z_s'Z_s = nI$.
+
+3. Reduced-form coefficients:
+$$\hat{\pi} = Z_s'\tilde{x}/n, \qquad \hat{d} = Z_s'\tilde{y}/n$$
+
+4. Reduced-form residuals:
+$$\hat{u}_x = \tilde{x} - Z_s\hat{\pi}, \qquad \hat{u}_y = \tilde{y} - Z_s\hat{d}$$
+
+5. Residual covariance ($\delta = n - \ell - p$):
+$$\Omega = \begin{pmatrix}\hat{u}_y'\hat{u}_y & \hat{u}_y'\hat{u}_x \\ \hat{u}_x'\hat{u}_y & \hat{u}_x'\hat{u}_x\end{pmatrix} / \delta$$
+
+6. Sandwich variance of stacked moments $M = [\hat{u}_y \odot Z_s,\;\hat{u}_x \odot Z_s]$ (size $n \times 2\ell$):
+$$W = \frac{\text{meat}(M,\;\texttt{vcov\_type})}{\delta \cdot c_{\text{clust}}}$$
+   where $c_{\text{clust}}$ is 1 for HC, or cluster DOF adjustment for CR. Extract:
+$$W_2 = W[\ell\!+\!1:2\ell,\;\ell\!+\!1:2\ell]$$
+
+7. Three F-statistics:
+
+$$F_{\text{nonrobust}} = \frac{n\,\hat{\pi}'\hat{\pi}}{\ell\,\omega_{22}}, \qquad \omega_{22} = \Omega[2,2]$$
+
+$$F_{\text{eff}} = \frac{n\,\hat{\pi}'\hat{\pi}}{\text{tr}(W_2)}$$
+
+$$F_{\text{robust}} = \frac{n\,\hat{\pi}'\,W_2^{-1}\,\hat{\pi}}{\ell}$$
+
+**Interpretation.** Compare $F_{\text{eff}}$ to `cv_TSLS`/`cv_LIML` and $F_{\text{robust}}$ to `cv_GMMf`. If $F > \text{cv}[\tau]$, worst-case bias is below $\tau$ of the OLS bias.
+
+**Access.**
+
+```julia
+r = weakivtest(m)
+r.F_eff, r.F_robust, r.F_nonrobust
+
+# Critical values at τ ∈ {5%, 10%, 20%, 30%}:
+r.cv_TSLS    # compare F_eff
+r.cv_LIML    # compare F_eff
+r.cv_GMMf    # compare F_robust
+
+# Estimator coefficients and SEs:
+r.btsls, r.sebtsls   # TSLS
+r.bliml, r.sebliml   # LIML
+r.bgmmf, r.sebgmmf   # GMMf
+r.kappa              # LIML kappa
+```
+
+---
+
+---
+
+## 4. Kleibergen-Paap rk Wald Statistic (internal)
+
+Joint rank test for under-identification. Computed at fitting time via `ranktest()` but **not currently stored** on the model struct — only the per-endogenous Wald F-statistics (Section 2) are exposed.
+
+**Notation.** Let $\hat\Pi$ be the $\ell \times k$ matrix of first-stage coefficients on excluded instruments (after partialling out exogenous regressors). Let $Z_{\text{res}}$ ($n \times \ell$) and $X_{\text{endo,res}}$ ($n \times k$) be residualized instruments and endogenous variables.
+
+**Computation.**
+
+1. Cholesky factorizations:
+$$F F' = Z_{\text{res}}'Z_{\text{res}}, \qquad G G' = X_{\text{endo,res}}'X_{\text{endo,res}}$$
+
+2. Normalized coefficient matrix and its SVD:
+$$\Theta = F\,\hat\Pi'\,(G')^{-1}, \qquad \Theta = U\,S\,V'$$
+
+3. Extract test direction from SVD submatrices at rank $k$:
+$$\lambda = (b_{kk} \otimes a_{kk}')\,\text{vec}(\Theta)$$
+
+4. Variance of $\lambda$:
+   - **IID:** $V_\lambda = (\text{kron}_v\,\text{kron}_v')\;/\;n$
+   - **Robust:** $V_\lambda = \text{kron}_v\;\hat{V}\;\text{kron}_v'$, where $\hat{V}$ is the sandwich variance of $\text{vec}(\hat\Pi)$ computed from the moment matrix $Z_{\text{res}} \odot \hat{e}$.
+
+5. Test statistic:
+$$r_{KP} = \lambda'\,V_\lambda^{-1}\,\lambda, \qquad F_{KP} = r_{KP}\;/\;\ell$$
+
+Under $H_0$ (rank deficiency), $r_{KP} \sim \chi^2(\ell - k + 1)$.
+
+**Access.**
+
+```julia
+r = first_stage_F_KP(m)
+r.stat      # F = r_KP / ℓ
+r.df1       # ℓ (number of excluded instruments)
+r.p         # p-value from χ²(ℓ − k + 1)
+```
+
+---
+
+## 5. Wu-Hausman Endogeneity Test (`wu_hausman`)
+
+Tests $H_0$: the instrumented variables are exogenous (OLS is consistent). Rejection suggests endogeneity and justifies IV estimation.
+
+**Computation.** Let $X = [X_{\text{exo}},\; X_{\text{endo}}]$ be the second-stage regressors and $\hat{v}$ the first-stage residuals ($n \times k$ matrix, from regressing each endogenous variable on all instruments).
+
+1. Restricted model (OLS, no endogeneity correction):
+$$\hat{e}_R = y - X(X'X)^{-1}X'y, \qquad \text{SSR}_R = \hat{e}_R'\hat{e}_R$$
+
+2. Unrestricted model (augmented with first-stage residuals):
+$$W = [X,\;\hat{v}], \qquad \hat{e}_U = y - W(W'W)^{-1}W'y, \qquad \text{SSR}_U = \hat{e}_U'\hat{e}_U$$
+
+3. F-statistic:
+$$F = \frac{(\text{SSR}_R - \text{SSR}_U)\;/\;k}{\text{SSR}_U\;/\;(d_{\text{res}} - k)}, \qquad p\text{-value from } F(k,\; d_{\text{res}} - k)$$
+
+where $k$ is the number of endogenous variables and $d_{\text{res}}$ is the second-stage residual degrees of freedom.
+
+**Access.**
+
+```julia
+r = wu_hausman(m)
+r.stat      # F-statistic
+r.p         # p-value
+r.df1       # k (number of endogenous variables)
+r.df2       # d_res − k
+```
+
+---
+
+## 6. Sargan Overidentification Test (`sargan`)
+
+Tests $H_0$: the excluded instruments are valid (uncorrelated with the structural error). Only meaningful when the model is overidentified ($\ell > k$).
+
+**Computation.** Let $e = y - X\hat\beta_{\text{IV}}$ be the second-stage residuals and $Z_{\text{full}} = [X_{\text{exo}},\; Z]$ the full instrument matrix.
+
+1. Auxiliary regression of residuals on all instruments:
+$$\hat\gamma = (Z_{\text{full}}'Z_{\text{full}})^{-1}Z_{\text{full}}'e, \qquad \hat{e}_{\text{aux}} = Z_{\text{full}}\,\hat\gamma$$
+
+2. $R^2$ from auxiliary regression:
+$$R^2 = 1 - \frac{\|e - \hat{e}_{\text{aux}}\|^2}{\|e\|^2}$$
+
+3. Test statistic:
+$$S = n \cdot R^2 \;\sim\; \chi^2(\ell - k)$$
+
+where $\ell$ is the number of excluded instruments and $k$ the number of endogenous variables.
+
+**Access.**
+
+```julia
+r = sargan(m)
+r.stat      # n × R² (χ² statistic)
+r.p         # p-value from χ²(ℓ − k)
+r.df        # ℓ − k
+```
+
+---
+
+## Summary
+
+### First-Stage Diagnostics
+
+| Statistic | Access | Variance | Scope |
+|-----------|--------|----------|-------|
+| IID F | `first_stage_F_iid(m).stat` | Homoskedastic | Per endogenous |
+| Robust Wald F | `first_stage_F_robust(m).stat` | Model's vcov | Per endogenous |
+| KP rk Wald F | `first_stage_F_KP(m).stat` | Model's vcov | Joint |
+
+### Weak Instrument Test
+
+| Statistic | Access | Variance | Compare to |
+|-----------|--------|----------|------------|
+| Effective F (MOP) | `weakivtest(m).F_eff` | Model's vcov | `cv_TSLS`, `cv_LIML` |
+| Robust F (Windmeijer) | `weakivtest(m).F_robust` | Model's vcov | `cv_GMMf` |
+| Non-robust F | `weakivtest(m).F_nonrobust` | Homoskedastic | — |
+
+### Specification Tests
+
+| Test | Access | $H_0$ | Distribution |
+|------|--------|-------|--------------|
+| Wu-Hausman | `wu_hausman(m)` | Endogenous vars are exogenous | $F(k, d_{\text{res}} - k)$ |
+| Sargan | `sargan(m)` | Instruments are valid | $\chi^2(\ell - k)$ |
+
+**References.**
+Montiel Olea & Pflueger (2013), *JBES*.
+Windmeijer (2025), *Journal of Econometrics*.
+Sargan (1958), *Econometrica*.
+Wu (1973), *Econometrica*; Hausman (1978), *Econometrica*.

--- a/src/IVModel.jl
+++ b/src/IVModel.jl
@@ -1,5 +1,97 @@
 ##############################################################################
 ##
+## Abstract Test Types
+##
+##############################################################################
+
+"""
+    AbstractTest
+
+Abstract supertype for test result types (first-stage F-tests, weak IV tests, etc.).
+"""
+abstract type AbstractTest end
+
+"""
+    Homoskedastic
+
+Sentinel type indicating the IID (homoskedastic) variance assumption.
+Used as the `K` type parameter in `FirstStageFTest{T, Homoskedastic}`.
+"""
+struct Homoskedastic end
+
+"""
+    FirstStageFTest{T, K} <: AbstractTest
+
+First-stage F-test result. Parametric on:
+- `T`: `Float64` (single endogenous or joint KP) or `Vector{Float64}` (multiple endogenous)
+- `K`: variance estimator type — `Homoskedastic` for IID, or a CovarianceMatrices type for robust/KP
+
+# Fields
+- `stat::T`: F-statistic value(s)
+- `df1::Int`: numerator degrees of freedom
+- `df2::Int`: denominator degrees of freedom (0 for asymptotic KP)
+- `p::T`: p-value(s)
+- `type::Symbol`: `:iid`, `:robust`, or `:kp`
+- `vcov_estimator::K`: variance estimator used
+- `endo_names::Vector{String}`: endogenous variable names
+
+# Examples
+```julia
+m = iv(TSLS(), df, @formula(y ~ x + (endo ~ z1 + z2)))
+first_stage_F_iid(m)      # IID F-test
+first_stage_F_robust(m)   # Robust Wald F-test
+first_stage_F_KP(m)       # Kleibergen-Paap rk Wald F-test
+```
+"""
+struct FirstStageFTest{T, K} <: AbstractTest
+    stat::T
+    df1::Int
+    df2::Int
+    p::T
+    type::Symbol
+    vcov_estimator::K
+    endo_names::Vector{String}
+end
+
+function Base.show(io::IO, f::FirstStageFTest{<:Real})
+    type_str = if f.type == :iid
+        "First-stage F-test (IID)"
+    elseif f.type == :kp
+        "Kleibergen-Paap rk Wald F-test"
+    else
+        vcov_name = string(typeof(f.vcov_estimator).name.name)
+        "First-stage F-test (robust, $vcov_name)"
+    end
+    println(io, type_str)
+    name = isempty(f.endo_names) ? "joint" : f.endo_names[1]
+    p_str = f.p < 0.001 ? "p < 0.001" : @sprintf("p = %.4f", f.p)
+    if f.df2 > 0
+        @printf(io, "  %s: F(%d, %d) = %.4f  (%s)\n", name, f.df1, f.df2, f.stat, p_str)
+    else
+        @printf(io, "  %s: F = %.4f, df = %d  (%s)\n", name, f.stat, f.df1, p_str)
+    end
+end
+
+function Base.show(io::IO, f::FirstStageFTest{<:AbstractVector})
+    type_str = if f.type == :iid
+        "First-stage F-test (IID)"
+    else
+        vcov_name = string(typeof(f.vcov_estimator).name.name)
+        "First-stage F-test (robust, $vcov_name)"
+    end
+    if f.df2 > 0
+        println(io, "$type_str, F($(f.df1), $(f.df2)):")
+    else
+        println(io, "$type_str:")
+    end
+    for (j, name) in enumerate(f.endo_names)
+        p_str = f.p[j] < 0.001 ? "p < 0.001" : @sprintf("p = %.4f", f.p[j])
+        @printf(io, "  %s: F = %.4f  (%s)\n", name, f.stat[j], p_str)
+    end
+end
+
+##############################################################################
+##
 ## Type IVEstimator (for IV estimation)
 ##
 ##############################################################################
@@ -277,6 +369,8 @@ struct IVEstimator{
     p_first_stage_nonrobust::Vector{T}
     F_first_stage_robust::Vector{T}
     p_first_stage_robust::Vector{T}
+    F_kp::T                 # Joint Kleibergen-Paap rk Wald F-statistic
+    p_kp::T                 # P-value of joint KP test
 end
 
 has_iv(::IVEstimator) = true
@@ -491,8 +585,8 @@ end
 @noinline residualadjustment(k::_CM.CR0, m::IVEstimator) = 1.0
 @noinline residualadjustment(k::_CM.CR1, m::IVEstimator) = 1.0
 
-# HAC (kernel) estimators - no residual adjustment needed
-@noinline residualadjustment(k::_CM.HAC, m::IVEstimator) = 1.0
+# Correlated estimators (HAC, EWC, DriscollKraay, VARHAC, etc.) - no residual adjustment needed
+@noinline residualadjustment(k::_CM.Correlated, m::IVEstimator) = 1.0
 
 # CR2 and CR3 for IV - leverage-adjusted cluster-robust
 function residualadjustment(k::_CM.CR2, m::IVEstimator)
@@ -1079,13 +1173,98 @@ function Base.:+(m::IVEstimator{T, E, V1, P}, v::VcovSpec{V2}) where {T, E, V1, 
         vcov_copy, Symmetric(vcov_mat), se, t_stats, p_values,
         F_stat, p_val,
         m.F_first_stage_nonrobust, m.p_first_stage_nonrobust,
-        F_first_stage_robust, p_first_stage_robust
+        F_first_stage_robust, p_first_stage_robust,
+        m.F_kp, m.p_kp  # KP stat doesn't change with vcov
     )
 end
 
 ##############################################################################
 ##
-## first_stage() - Return first-stage diagnostics as a struct
+## New First-Stage F-Test API
+##
+##############################################################################
+
+"""
+    first_stage_F_iid(m::IVEstimator) -> FirstStageFTest
+
+IID (homoskedastic) first-stage F-test. Equation-by-equation SSR-based F-test.
+"""
+function first_stage_F_iid(m::IVEstimator{T}) where {T}
+    pe = m.postestimation
+    F_vec = m.F_first_stage_nonrobust
+    p_vec = m.p_first_stage_nonrobust
+
+    df1, df2 = first_stage_df(m)
+    endo_names = if !isnothing(pe) && has_first_stage_data(pe.first_stage_data)
+        pe.first_stage_data.endogenous_names
+    else
+        String["endo$i" for i in 1:length(F_vec)]
+    end
+
+    if length(F_vec) == 1
+        return FirstStageFTest{T, Homoskedastic}(
+            F_vec[1], df1, df2, p_vec[1], :iid, Homoskedastic(), endo_names)
+    else
+        return FirstStageFTest{Vector{T}, Homoskedastic}(
+            F_vec, df1, df2, p_vec, :iid, Homoskedastic(), endo_names)
+    end
+end
+
+"""
+    first_stage_F_robust(m::IVEstimator) -> FirstStageFTest
+
+Robust Wald first-stage F-test using the model's current variance estimator.
+"""
+function first_stage_F_robust(m::IVEstimator{T}) where {T}
+    pe = m.postestimation
+    F_vec = m.F_first_stage_robust
+    p_vec = m.p_first_stage_robust
+
+    df1, df2 = first_stage_df(m)
+    endo_names = if !isnothing(pe) && has_first_stage_data(pe.first_stage_data)
+        pe.first_stage_data.endogenous_names
+    else
+        String["endo$i" for i in 1:length(F_vec)]
+    end
+
+    vcov_est = m.vcov_estimator
+
+    if length(F_vec) == 1
+        return FirstStageFTest{T, typeof(vcov_est)}(
+            F_vec[1], df1, df2, p_vec[1], :robust, vcov_est, endo_names)
+    else
+        return FirstStageFTest{Vector{T}, typeof(vcov_est)}(
+            F_vec, df1, df2, p_vec, :robust, vcov_est, endo_names)
+    end
+end
+
+"""
+    first_stage_F_KP(m::IVEstimator) -> FirstStageFTest
+
+Joint Kleibergen-Paap rk Wald F-test for under-identification.
+"""
+function first_stage_F_KP(m::IVEstimator{T}) where {T}
+    pe = m.postestimation
+    endo_names = if !isnothing(pe) && has_first_stage_data(pe.first_stage_data)
+        pe.first_stage_data.endogenous_names
+    else
+        String[]
+    end
+
+    n_excl = if !isnothing(pe) && has_first_stage_data(pe.first_stage_data)
+        size(pe.first_stage_data.Z_res, 2)
+    else
+        0
+    end
+
+    # KP is asymptotically χ²(df)/ℓ, use df2=0 to signal asymptotic
+    return FirstStageFTest{T, typeof(m.vcov_estimator)}(
+        m.F_kp, n_excl, 0, m.p_kp, :kp, m.vcov_estimator, endo_names)
+end
+
+##############################################################################
+##
+## first_stage() - Return first-stage diagnostics as a struct (DEPRECATED)
 ##
 ##############################################################################
 
@@ -1738,8 +1917,8 @@ end
     return @. sqrt(T(1) / (T(1) - h)^δ)
 end
 
-# HAC (Bartlett, Parzen, etc.) - no adjustment needed
-@noinline residualadjustment(k::_CM.HAC, m::IVMatrixEstimator) = 1.0
+# Correlated estimators (HAC, EWC, DriscollKraay, VARHAC, etc.) - no adjustment needed
+@noinline residualadjustment(k::_CM.Correlated, m::IVMatrixEstimator) = 1.0
 
 # CR (cluster-robust) - no individual residual adjustment needed (handled in aVar)
 @noinline residualadjustment(k::_CM.CR0, m::IVMatrixEstimator) = 1.0

--- a/src/Regress.jl
+++ b/src/Regress.jl
@@ -92,15 +92,23 @@ public ols, iv, fe
 # export AbstractIVEstimator
 export TSLS, LIML, Fuller, KClass
 
-# First-stage diagnostics
+# Formula terms
+export lags, LagTerm
+
+# First-stage diagnostics (new API)
+export AbstractTest, FirstStageFTest, Homoskedastic
+export first_stage_F_iid, first_stage_F_robust, first_stage_F_KP
+
+# First-stage diagnostics (deprecated, kept for compatibility)
 export first_stage, FirstStageIV
+export first_stage_f, FirstStageFResult
 
 # Weak instrument test
 export weakivtest, WeakIVTestResult
 
 # IV diagnostic tests
-export first_stage_f, wu_hausman, sargan
-export FirstStageFResult, WuHausmanResult, SarganResult
+export wu_hausman, sargan
+export WuHausmanResult, SarganResult
 
 # Utility functions
 # export partial_out

--- a/src/estimators/kclass.jl
+++ b/src/estimators/kclass.jl
@@ -116,6 +116,11 @@ function fit_kclass_estimator(
 
     coef_names = vcat(coefnames_exo, coefnames_endo)
 
+    # Filter rows with NaN (e.g. from lags() producing NaN for out-of-bounds entries)
+    y, (Xexo, Xendo, Z), wts, subfes, nobs_eff,
+    has_nan_rows, nan_rows = _filter_nan_rows(
+        y, (Xexo, Xendo, Z), wts, subfes)
+
     # Compute total sum of squares
     tss_total = tss(y, data_prep.has_intercept | data_prep.has_fe_intercept, wts)
 
@@ -207,7 +212,7 @@ function fit_kclass_estimator(
     elseif estimator isa Fuller
         kappa_liml = _liml_kappa(y, Xendo, Z, Xexo)
         # Fuller adjustment: kappa = kappa_liml - a/(n - L - p)
-        n = data_prep.nobs
+        n = nobs_eff
         L = k_z_final  # Number of excluded instruments
         p = k_exo_final  # Number of exogenous variables
         adj_denom = n - L - p
@@ -262,6 +267,7 @@ function fit_kclass_estimator(
     p_first_stage_nonrobust = T[]
     F_first_stage_robust = T[]
     p_first_stage_robust = T[]
+    F_kp_joint, p_kp_joint = T(NaN), T(NaN)
     first_stage_data = empty_first_stage_data(T)
     newZ = hcat(Xexo, Z)  # Needed for PostEstimationData leverage computation
 
@@ -289,7 +295,7 @@ function fit_kclass_estimator(
 
         fstats = _iv_first_stage_fstats_standard(
             Xendo, newZ, Pi, XexoXexo, XexoZ, ZZ, X,
-            data_prep.nobs, dof_fes_local, endo_names_final,
+            nobs_eff, dof_fes_local, endo_names_final,
             k_exo_final, data_prep.has_intercept)
 
         first_stage_data = fstats.first_stage_data
@@ -297,7 +303,8 @@ function fit_kclass_estimator(
         p_first_stage_robust = fstats.F_kp_per_endo, fstats.p_kp_per_endo
         F_first_stage_nonrobust,
         p_first_stage_nonrobust,
-        _, _ = _compute_first_stage_f_iid(first_stage_data, data_prep.nobs, dof_fes_local)
+        _, _ = _compute_first_stage_f_iid(first_stage_data, nobs_eff, dof_fes_local)
+        F_kp_joint, p_kp_joint = fstats.F_kp, fstats.p_kp
     end
 
     ##############################################################################
@@ -316,7 +323,7 @@ function fit_kclass_estimator(
     # Degrees of freedom
     ngroups_fes = [nunique(fe) for fe in subfes]
     dof_fes = sum(ngroups_fes)
-    dof_residual = max(1, data_prep.nobs - size(X, 2) - dof_fes - dof_add)
+    dof_residual = max(1, nobs_eff - size(X, 2) - dof_fes - dof_add)
 
     # R-squared (use raw weighted residuals for RSS)
     rss = sum(abs2, residuals_raw)
@@ -422,8 +429,12 @@ function fit_kclass_estimator(
         end
     end
 
-    esample_final = data_prep.esample == Colon() ? trues(data_prep.nrows) :
-                    data_prep.esample
+    esample_final = data_prep.esample isa Colon ? trues(data_prep.nrows) :
+                    BitVector(data_prep.esample)
+    if has_nan_rows
+        idx = findall(esample_final)
+        esample_final[idx[nan_rows]] .= false
+    end
 
     ##############################################################################
     ## Compute Default Vcov (HC1) and Related Statistics
@@ -433,7 +444,7 @@ function fit_kclass_estimator(
     # and the "meat" uses Adj (stored in X field of postestimation_data)
 
     # Compute HC1 vcov: invA * (Adj .* u)' * (Adj .* u) * invA * scale
-    n = data_prep.nobs
+    n = nobs_eff
     k = size(X, 2)
     scale = n / dof_residual
 
@@ -470,13 +481,14 @@ function fit_kclass_estimator(
         postestimation_data,
         data_prep.fekeys, coef_names, response_name,
         data_prep.formula_origin, formula_schema, contrasts,
-        data_prep.nobs, dof_model, dof_fes, dof_residual,
+        nobs_eff, dof_model, dof_fes, dof_residual,
         rss, tss_total,
         iterations, converged, r2_within,
         default_vcov, vcov_matrix, se, t_stats, p_values,
         F_stat_robust, p_val_robust,
         F_first_stage_nonrobust, p_first_stage_nonrobust,
-        F_first_stage_robust, p_first_stage_robust
+        F_first_stage_robust, p_first_stage_robust,
+        F_kp_joint, p_kp_joint
     )
 end
 

--- a/src/estimators/tsls.jl
+++ b/src/estimators/tsls.jl
@@ -502,6 +502,11 @@ function fit_tsls(@nospecialize(df),
     formula_schema = FormulaTerm(formula_schema.lhs, MatrixTerm(Tuple(schema_terms)))
     coef_names = vcat(coefnames_exo, coefnames_endo)
 
+    # Filter rows with NaN (e.g. from lags() producing NaN for out-of-bounds entries)
+    y, (Xexo, Xendo, Z), wts, subfes, nobs_eff,
+    has_nan_rows, nan_rows = _filter_nan_rows(
+        y, (Xexo, Xendo, Z), wts, subfes)
+
     # Compute TSS and validate
     tss_total = tss(y, data_prep.has_intercept | data_prep.has_fe_intercept, wts)
     all(isfinite, wts) || throw("Weights are not finite")
@@ -605,6 +610,7 @@ function fit_tsls(@nospecialize(df),
 
     F_first_stage_nonrobust, p_first_stage_nonrobust = T[], T[]
     F_first_stage_robust, p_first_stage_robust = T[], T[]
+    F_kp_joint, p_kp_joint = T(NaN), T(NaN)
     first_stage_data = empty_first_stage_data(T)
 
     if first_stage && k_endo_final > 0
@@ -617,12 +623,12 @@ function fit_tsls(@nospecialize(df),
 
         if has_fe_iv
             fstats = _iv_first_stage_fstats_fe(
-                Xendo, Xendo_hat, iv_fes, newZ, data_prep.nobs, k_exo_final,
+                Xendo, Xendo_hat, iv_fes, newZ, nobs_eff, k_exo_final,
                 endo_names_final, data_prep.has_intercept)
         else
             fstats = _iv_first_stage_fstats_standard(
                 Xendo, newZ, Pi, XexoXexo, XexoZ, ZZ, X,
-                data_prep.nobs, dof_fes_local, endo_names_final,
+                nobs_eff, dof_fes_local, endo_names_final,
                 k_exo_final, data_prep.has_intercept)
         end
 
@@ -631,7 +637,8 @@ function fit_tsls(@nospecialize(df),
         p_first_stage_robust = fstats.F_kp_per_endo, fstats.p_kp_per_endo
         F_first_stage_nonrobust,
         p_first_stage_nonrobust,
-        _, _ = _compute_first_stage_f_iid(first_stage_data, data_prep.nobs, dof_fes_local)
+        _, _ = _compute_first_stage_f_iid(first_stage_data, nobs_eff, dof_fes_local)
+        F_kp_joint, p_kp_joint = fstats.F_kp, fstats.p_kp
     end
 
     ##########################################################################
@@ -645,7 +652,7 @@ function fit_tsls(@nospecialize(df),
     dof_fes = sum(ngroups_fes)
 
     # dof_residual uses all parameters in X (intercept is in X when no FE)
-    dof_residual = max(1, data_prep.nobs - size(X, 2) - dof_fes - dof_add)
+    dof_residual = max(1, nobs_eff - size(X, 2) - dof_fes - dof_add)
     # dof_model excludes intercept (for F-test numerator DOF)
     dof_model = size(X, 2) - (data_prep.has_intercept & !data_prep.has_fe_intercept)
 
@@ -719,8 +726,12 @@ function fit_tsls(@nospecialize(df),
         end
     end
 
-    esample_final = data_prep.esample == Colon() ? trues(data_prep.nrows) :
-                    data_prep.esample
+    esample_final = data_prep.esample isa Colon ? trues(data_prep.nrows) :
+                    BitVector(data_prep.esample)
+    if has_nan_rows
+        idx = findall(esample_final)
+        esample_final[idx[nan_rows]] .= false
+    end
 
     ##########################################################################
     ## Compute Inference
@@ -728,7 +739,7 @@ function fit_tsls(@nospecialize(df),
 
     inf = _iv_compute_inference(
         convert(Matrix{T}, Xhat), residuals_raw, invXhatXhat, basis_coef, coef,
-        data_prep.nobs, dof_model, dof_fes, dof_residual, data_prep.formula_origin)
+        nobs_eff, dof_model, dof_fes, dof_residual, data_prep.formula_origin)
 
     ##########################################################################
     ## Return IVEstimator
@@ -741,12 +752,13 @@ function fit_tsls(@nospecialize(df),
         postestimation_data,
         data_prep.fekeys, coef_names, response_name,
         data_prep.formula_origin, formula_schema, contrasts,
-        data_prep.nobs, dof_model, dof_fes, dof_residual,
+        nobs_eff, dof_model, dof_fes, dof_residual,
         rss, tss_total,
         iterations, converged, r2_within,
         CovarianceMatrices.HC1(), inf.vcov_matrix, inf.se, inf.t_stats, inf.p_values,
         inf.F_stat_robust, inf.p_val_robust,
         F_first_stage_nonrobust, p_first_stage_nonrobust,
-        F_first_stage_robust, p_first_stage_robust
+        F_first_stage_robust, p_first_stage_robust,
+        F_kp_joint, p_kp_joint
     )
 end

--- a/src/fit_ols.jl
+++ b/src/fit_ols.jl
@@ -100,6 +100,11 @@ function fit_ols(@nospecialize(df),
     X = convert(Matrix{T}, modelmatrix(formula_schema, subdf))
     response_name, coef_names = coefnames(formula_schema)
 
+    # Filter rows with NaN (e.g. from lags() producing NaN for out-of-bounds entries)
+    y, (X,), wts, subfes, nobs_eff,
+    has_nan_rows, nan_rows = _filter_nan_rows(
+        y, (X,), wts, subfes)
+
     # Build response object (fitted values will be set after solve)
     rr = build_response(y, wts, Symbol(response_name))
 
@@ -192,7 +197,7 @@ function fit_ols(@nospecialize(df),
     ngroups_fes = [nunique(fe) for fe in subfes]
     dof_fes = sum(ngroups_fes)
     dof_model = sum(basis_coef)  # Only non-collinear coefficients
-    dof_residual = max(1, data_prep.nobs - dof_model - dof_fes - dof_add)
+    dof_residual = max(1, nobs_eff - dof_model - dof_fes - dof_add)
 
     # R-squared
     r2 = 1 - rss / tss_total
@@ -261,8 +266,13 @@ function fit_ols(@nospecialize(df),
     ##############################################################################
 
     # Handle Colon case for esample
-    esample_final = data_prep.esample == Colon() ? trues(data_prep.nrows) :
-                    data_prep.esample
+    esample_final = data_prep.esample isa Colon ? trues(data_prep.nrows) :
+                    BitVector(data_prep.esample)
+    # Update esample to reflect NaN-filtered rows (e.g. from lags())
+    if has_nan_rows
+        idx = findall(esample_final)
+        esample_final[idx[nan_rows]] .= false
+    end
 
     ##############################################################################
     ## Convert coefficient names to strings
@@ -288,7 +298,7 @@ function fit_ols(@nospecialize(df),
     vcov_matrix = if save_matrices
         compute_hc1_vcov_direct(
             pp.X, residuals_vcov, invXX, basis_coef,
-            data_prep.nobs, dof_model, dof_fes, dof_residual
+            nobs_eff, dof_model, dof_fes, dof_residual
         )
     else
         # Minimal mode: can't compute vcov without X
@@ -331,7 +341,7 @@ function fit_ols(@nospecialize(df),
         data_prep.formula_origin, formula_schema, contrasts,
         esample_final,
         coef_names_str, basis_coef,
-        data_prep.nobs, dof_model, dof_fes, dof_residual,
+        nobs_eff, dof_model, dof_fes, dof_residual,
         T(tss_total), T(tss_partial), T(rss),
         T(r2), T(r2_within),
         data_prep.has_intercept,

--- a/src/utils/covariance.jl
+++ b/src/utils/covariance.jl
@@ -781,8 +781,8 @@ end
 @noinline residualadjustment(k::CM.CR0, r::OLSModel) = 1.0
 @noinline residualadjustment(k::CM.CR1, r::OLSModel) = 1.0
 
-# HAC (kernel) estimators - no residual adjustment needed
-@noinline residualadjustment(k::CM.HAC, r::OLSModel) = 1.0
+# Correlated estimators (HAC, EWC, DriscollKraay, VARHAC, etc.) - no residual adjustment needed
+@noinline residualadjustment(k::CM.Correlated, r::OLSModel) = 1.0
 
 """
     _get_group_ranges(g)
@@ -1073,8 +1073,8 @@ function CM.vcov(k::CM.AbstractAsymptoticVarianceEstimator, m::OLSEstimator; dof
         #   - FE nested in cluster variable are NOT counted in K
         #   - FE NOT nested in cluster variable ARE counted in K
         _cluster_robust_scale(k, m, n)
-    elseif k isa CM.HAC
-        # HAC: Apply DOF correction n/(n-p) to match CovarianceMatrices/GLM behavior
+    elseif k isa CM.Correlated
+        # Correlated (HAC, EWC, etc.): Apply DOF correction n/(n-p)
         # p_total includes both model parameters and fixed effects DOF
         p_total = dof(m) + dof_fes(m)
         n * n / (n - p_total)
@@ -1261,8 +1261,8 @@ function CM.vcov(k::CM.AbstractAsymptoticVarianceEstimator, m::OLSMatrixEstimato
         K = dof(m)
         K_adj = (n - 1) / (n - K)
         convert(Float64, n * G_adj * K_adj)
-    elseif k isa CM.HAC
-        # HAC: Apply DOF correction n/(n-p) to match CovarianceMatrices/GLM behavior
+    elseif k isa CM.Correlated
+        # Correlated (HAC, EWC, etc.): Apply DOF correction n/(n-p)
         # For matrix estimator, no fixed effects so p = dof(m)
         p = dof(m)
         n * n / (n - p)

--- a/src/utils/fit_common.jl
+++ b/src/utils/fit_common.jl
@@ -568,3 +568,41 @@ function partial_out_fixed_effects!(cols::Vector,
 
     return feM, iterations, converged, tss_partial, oldy, oldX
 end
+
+##############################################################################
+##
+## NaN Row Filtering (shared by OLS, TSLS, K-class)
+##
+##############################################################################
+
+"""
+    _filter_nan_rows(y, matrices, wts, subfes)
+
+Filter rows containing NaN from response `y` and design matrices (e.g. from `lags()`).
+Returns `(y, matrices, wts, subfes, nobs_eff, has_nan_rows, nan_rows)`.
+`matrices` is a tuple of matrices; the returned tuple preserves the same order.
+"""
+function _filter_nan_rows(y::Vector{T}, matrices::NTuple{N, Matrix{T}},
+        wts, subfes) where {T, N}
+    nan_rows = isnan.(y)
+    for M in matrices
+        size(M, 2) > 0 && (nan_rows .|= vec(any(isnan, M, dims = 2)))
+    end
+    has_nan_rows = any(nan_rows)
+    nobs_eff = length(y)
+    if !has_nan_rows
+        return y, matrices, wts, subfes, nobs_eff, false, nan_rows
+    end
+    keep = .!nan_rows
+    y = y[keep]
+    filtered = ntuple(i -> matrices[i][keep, :], Val(N))
+    nobs_eff = sum(keep)
+    if !(wts isa UnitWeights)
+        wts = Weights(Vector(wts)[keep])
+    else
+        wts = uweights(nobs_eff)
+    end
+    subfes = isempty(subfes) ? subfes :
+             FixedEffect[fe[keep] for fe in subfes]
+    return y, filtered, wts, subfes, nobs_eff, true, nan_rows
+end

--- a/src/utils/formula.jl
+++ b/src/utils/formula.jl
@@ -292,3 +292,100 @@ end
 # Backward compatibility aliases for tests
 const _multiply = _multiply_columns
 const _parse_fixedeffect = _parse_fixedeffect_term
+
+##############################################################################
+##
+## Lag Term (lags)
+##
+##############################################################################
+
+"""
+    _lag_vector(v::AbstractVector, n::Int; default=NaN)
+
+Shift vector `v` by `n` positions, filling leading entries with `default`.
+"""
+function _lag_vector(v::AbstractVector, n::Int; default = NaN)
+    T = promote_type(eltype(v), typeof(default))
+    out = Vector{T}(undef, length(v))
+    @inbounds for i in eachindex(out)
+        out[i] = i <= n ? default : v[i - n]
+    end
+    return out
+end
+
+"""
+    lags(term, n)
+
+Create multiple lag columns from 1 to n. Used in formulas like
+`@formula(y ~ lags(x, 5))` to create a matrix with lag(x,1), ..., lag(x,5).
+"""
+lags(t::T, n::Int) where {T <: AbstractTerm} = LagTerm{T}(t, n)
+
+struct LagTerm{T <: AbstractTerm} <: AbstractTerm
+    term::T
+    nsteps::Int
+end
+
+StatsModels.terms(t::LagTerm) = StatsModels.terms(t.term)
+StatsModels.needs_schema(::LagTerm) = false
+
+function _parse_lags_args(t::FunctionTerm)
+    if length(t.args) == 1
+        return (first(t.args), 1)
+    elseif length(t.args) == 2
+        term, param_arg = t.args
+        (param_arg isa ConstantTerm) ||
+            throw(ArgumentError("lags parameter must be a number (got $param_arg)"))
+        return (term, param_arg.n)
+    else
+        throw(ArgumentError("lags() requires 1 or 2 arguments"))
+    end
+end
+
+function _termvars_lags(t::FunctionTerm)
+    length(t.args) >= 1 && return StatsModels.termvars(t.args[1])
+    return Symbol[]
+end
+
+function StatsModels.apply_schema(
+        t::FunctionTerm{typeof(lags)}, sch::StatsModels.Schema, ctx::Type)
+    term, nsteps = _parse_lags_args(t)
+    term = apply_schema(term, sch, ctx)
+    return LagTerm{typeof(term)}(term, nsteps)
+end
+
+function StatsModels.apply_schema(t::LagTerm, sch::StatsModels.Schema, ctx::Type)
+    term = apply_schema(t.term, sch, ctx)
+    LagTerm{typeof(term)}(term, t.nsteps)
+end
+
+function StatsModels.modelcols(ll::LagTerm, d::Tables.ColumnTable)
+    original_cols = StatsModels.modelcols(ll.term, d)
+    original_cols isa AbstractVector || throw(ArgumentError(
+        "lags() requires a single-column term; got a multi-column term " *
+        "(e.g., interaction or categorical). Apply lags to each variable separately."))
+    n = length(original_cols)
+    nsteps = ll.nsteps
+    result = Matrix{eltype(original_cols)}(undef, n, nsteps)
+    for i in 1:nsteps
+        result[:, i] = _lag_vector(original_cols, i; default = NaN)
+    end
+    return result
+end
+
+StatsModels.width(ll::LagTerm) = ll.nsteps
+
+StatsModels.termvars(t::FunctionTerm{typeof(lags)}) = _termvars_lags(t)
+StatsModels.termvars(ll::LagTerm) = StatsModels.termvars(ll.term)
+
+function Base.show(io::IO, ll::LagTerm)
+    print(io, "lags($(ll.term), $(ll.nsteps))")
+end
+
+function StatsModels.coefnames(ll::LagTerm)
+    base_name = StatsModels.coefnames(ll.term)
+    if base_name isa AbstractVector
+        base_name = base_name[1]
+    end
+    return [base_name * "_lag$i" for i in 1:ll.nsteps]
+end

--- a/src/utils/ranktest.jl
+++ b/src/utils/ranktest.jl
@@ -179,19 +179,18 @@ function _compute_meat(
         scale = n / dof_residual
         return scale * (moment_matrix' * moment_matrix)
     elseif vcov_type isa Union{CovarianceMatrices.CR0, CovarianceMatrices.CR1}
-        # Cluster-robust - vcov_type.g contains actual cluster vectors (not symbols)
-        clusters = vcov_type.g[1]
-        unique_clusters = unique(clusters)
-        n_clusters = length(unique_clusters)
+        # Cluster-robust - vcov_type.g[1] is a Clustering struct
+        clustering = vcov_type.g[1]
+        groups = clustering.groups       # Vector{Int}, 1-indexed
+        n_clusters = clustering.ngroups
+        p = size(moment_matrix, 2)
 
-        # Create mapping from cluster value to index
-        cluster_to_idx = Dict(c => i for (i, c) in enumerate(unique_clusters))
-
-        # Sum moments within clusters
-        cluster_sums = zeros(T, n_clusters, size(moment_matrix, 2))
-        for (i, c) in enumerate(clusters)
-            idx = cluster_to_idx[c]
-            cluster_sums[idx, :] .+= moment_matrix[i, :]
+        # Sum moments within clusters (column-major loop)
+        cluster_sums = zeros(T, n_clusters, p)
+        @inbounds for j in 1:p
+            for i in 1:n
+                cluster_sums[groups[i], j] += moment_matrix[i, j]
+            end
         end
 
         meat = cluster_sums' * cluster_sums
@@ -297,145 +296,48 @@ function compute_per_endogenous_fstats(
         Xendo_orig::Union{Matrix{T}, Nothing} = nothing,
         newZ::Union{Matrix{T}, Nothing} = nothing
 ) where {T <: AbstractFloat}
-    k = size(Xendo_res, 2)  # Number of endogenous variables
     l = size(Z_res, 2)      # Number of excluded instruments
 
-    # Use original data for robust F-stats if available
-    use_original = !isnothing(Xendo_orig) && !isnothing(newZ) &&
-                   !(vcov_type isa CovarianceMatrices.Uncorrelated)
-
-    if use_original
-        # Use batched version for better performance - computes ZZ etc. only once
-        return _compute_robust_first_stage_fstats_batched(
-            newZ, Xendo_orig, l, vcov_type, nobs, dof_small, dof_fes
+    if !isnothing(Xendo_orig) && !isnothing(newZ)
+        return _compute_first_stage_fstats_via_ols(
+            newZ, Xendo_orig, l, vcov_type, dof_fes
         )
     else
-        # Fall back to per-variable computation for classical F-test
-        F_stats = Vector{T}(undef, k)
-        p_values = Vector{T}(undef, k)
-
-        for j in 1:k
-            residuals_j = Xendo_res[:, j] .- Z_res * Pi[:, j]
-            F_j,
-            p_j = _compute_single_first_stage_fstat(
-                Z_res, Pi[:, j], residuals_j, vcov_type, nobs, dof_small, dof_fes
-            )
-            F_stats[j] = F_j
-            p_values[j] = p_j
-        end
-
-        return F_stats, p_values
+        throw(ArgumentError(
+            "compute_per_endogenous_fstats requires Xendo_orig and newZ; " *
+            "these must be provided from FirstStageData"))
     end
 end
 
 """
-    _compute_single_first_stage_fstat(Z, pi, residuals, vcov_type, nobs, dof_small, dof_fes)
+    _compute_first_stage_fstats_via_ols(newZ, Xendo, n_instruments, vcov_type, dof_fes)
 
-Compute F-statistic for a single first-stage regression.
+Compute first-stage F-statistics by constructing lightweight OLSMatrixEstimator models
+from pre-computed first-stage data and delegating variance computation to CovarianceMatrices.jl.
 
-Tests H0: pi = 0 (all excluded instrument coefficients are zero).
-
-# Arguments
-- `Z::Matrix{T}`: Instrument matrix (n × l)
-- `pi::Vector{T}`: First-stage coefficient vector (l × 1)
-- `residuals::Vector{T}`: First-stage residuals (n × 1)
-- `vcov_type`: Variance estimator type
-- `nobs::Int`: Number of observations
-- `dof_small::Int`: Degrees of freedom
-- `dof_fes::Int`: Degrees of freedom absorbed by FE
-
-# Returns
-- `(F, p)`: F-statistic and p-value
-"""
-function _compute_single_first_stage_fstat(
-        Z::Matrix{T},
-        pi::Vector{T},
-        residuals::Vector{T},
-        vcov_type,
-        nobs::Int,
-        dof_small::Int,
-        dof_fes::Int
-) where {T <: AbstractFloat}
-    l = length(pi)  # Number of excluded instruments
-
-    l == 0 && return T(NaN), T(NaN)
-
-    dof_residual = max(1, nobs - dof_small - dof_fes)
-
-    # Compute Z'Z and its Cholesky
-    ZZ = Symmetric(Z' * Z)
-    ZZ_chol = cholesky(ZZ; check = false)
-    !issuccess(ZZ_chol) && return T(NaN), T(NaN)
-
-    # Note: HR0/HR1 (= HC0/HC1) are heteroskedasticity-robust estimators.
-    # Only truly homoskedastic estimators (Uncorrelated) should use classical F-test.
-    if vcov_type isa CovarianceMatrices.Uncorrelated
-        # Classical F-test (homoskedastic): F = (pi' * Z'Z * pi) / (l * s²)
-        rss = sum(abs2, residuals)
-        s2 = rss / dof_residual
-
-        # Wald test: chi² = pi' * (Z'Z) * pi / s²
-        chi2 = (pi' * ZZ * pi) / s2
-        F = chi2 / l
-
-        p = fdistccdf(l, dof_residual, F)
-        return F, p
-    else
-        # Robust F-test (HC0/HC1/HC2/HC3/cluster) using sandwich variance
-        # Build moment matrix for this first-stage: M = Z .* residuals
-        M = Z .* residuals
-
-        # Compute meat of sandwich
-        meat = _compute_meat(M, vcov_type, nobs, dof_small, dof_fes)
-
-        # Bread: (Z'Z)^{-1} via Cholesky solve
-        invZZ = ZZ_chol \ I
-
-        # Sandwich vcov: invZZ * (n * Meat) * invZZ
-        # Note: _compute_meat already includes scaling
-        vcov_pi = Symmetric(invZZ * meat * invZZ)
-
-        # Wald test: chi² = pi' * inv(V) * pi
-        vcov_pi_chol = cholesky(Symmetric(vcov_pi); check = false)
-        !issuccess(vcov_pi_chol) && return T(NaN), T(NaN)
-
-        chi2 = pi' * (vcov_pi_chol \ pi)
-        F = chi2 / l
-
-        p = fdistccdf(l, dof_residual, F)
-        return F, p
-    end
-end
-
-"""
-    _compute_robust_first_stage_fstats_batched(newZ, Xendo, n_instruments, vcov_type, nobs, dof_small, dof_fes)
-
-Batched version that computes robust F-statistics for ALL endogenous variables at once.
-Avoids redundant computation of ZZ, ZZ_chol, invZZ which are shared across all k endogenous.
+No refitting is performed — ZZ factorization is computed once and shared across all
+endogenous variables. Per-endogenous cost is one matvec (for fitted values) plus the
+CovarianceMatrices sandwich formula.
 
 # Arguments
 - `newZ::Matrix{T}`: Full first-stage design matrix [Xexo, Z] (n × (k_exo + l))
 - `Xendo::Matrix{T}`: Original endogenous variables (n × k)
 - `n_instruments::Int`: Number of excluded instruments (l)
-- `vcov_type`: Variance estimator type (HC0/HC1/etc.)
-- `nobs::Int`: Number of observations
-- `dof_small::Int`: Total DOF for second-stage
-- `dof_fes::Int`: Degrees of freedom absorbed by FE
+- `vcov_type`: Any variance estimator supported by CovarianceMatrices.jl
+- `dof_fes::Int`: Degrees of freedom absorbed by fixed effects
 
 # Returns
 - `(F_stats, p_values)`: Vectors of F-statistics and p-values, one per endogenous
 """
-function _compute_robust_first_stage_fstats_batched(
+function _compute_first_stage_fstats_via_ols(
         newZ::Matrix{T},
         Xendo::Matrix{T},
         n_instruments::Int,
         vcov_type,
-        nobs::Int,
-        dof_small::Int,
         dof_fes::Int
 ) where {T <: AbstractFloat}
-    n, k_total = size(newZ)  # k_total = k_exo + l
-    k = size(Xendo, 2)       # Number of endogenous variables
+    n, k_total = size(newZ)
+    k = size(Xendo, 2)
     l = n_instruments
     k_exo = k_total - l
 
@@ -448,7 +350,7 @@ function _compute_robust_first_stage_fstats_batched(
         return F_stats, p_values
     end
 
-    # Compute ZZ and its factorization ONCE for all endogenous
+    # Compute ZZ factorization ONCE for all endogenous
     ZZ = Matrix{T}(undef, k_total, k_total)
     BLAS.syrk!('U', 'T', one(T), newZ, zero(T), ZZ)
     ZZ_sym = Symmetric(ZZ, :U)
@@ -459,65 +361,56 @@ function _compute_robust_first_stage_fstats_batched(
         return F_stats, p_values
     end
 
-    # Compute Zy for ALL endogenous at once: newZ' * Xendo is k_total × k
-    Zy_all = newZ' * Xendo  # k_total × k
-
-    # Compute all coefficients at once: coef_full_all is k_total × k
-    coef_full_all = ZZ_chol \ Zy_all
-
-    # Compute all residuals at once: Xendo - newZ * coef_full_all is n × k
-    # Use in-place update: residuals_all = Xendo - newZ * coef_full_all
-    residuals_all = copy(Xendo)
-    BLAS.gemm!('N', 'N', -one(T), newZ, coef_full_all, one(T), residuals_all)
-
-    # (Z'Z)^{-1} needed for sandwich - compute once via Cholesky solve
-    invZZ = ZZ_chol \ I
+    # Compute all coefficients at once: coef_all is k_total × k
+    coef_all = ZZ_chol \ (newZ' * Xendo)
 
     # DOF for first-stage
+    dof_fs = k_total
     dof_residual_fs = max(1, n - k_total - dof_fes)
-
-    # Pre-allocate buffers reused across all endogenous variables
-    M = Matrix{T}(undef, n, k_total)
-    meat_buf = Matrix{T}(undef, k_total, k_total)
-    vcov_full = Matrix{T}(undef, k_total, k_total)
-    tmp_buf = Matrix{T}(undef, k_total, k_total)
-    pi_tmp = Vector{T}(undef, l)
 
     # Process each endogenous variable
     for j in 1:k
-        residuals_j = @view residuals_all[:, j]
+        y_j = Xendo[:, j]
+        beta_j = coef_all[:, j]
+        mu_j = newZ * beta_j  # fitted values (one matvec per endogenous)
 
-        # Build moment matrix in-place: M = newZ .* residuals_j
-        @inbounds for col in 1:k_total
-            @simd for row in 1:n
-                M[row, col] = newZ[row, col] * residuals_j[row]
-            end
+        # Construct lightweight OLSMatrixEstimator wrapping pre-computed data
+        rr = OLSResponse(y_j, mu_j, T[], T[], :first_stage)
+        pp = OLSPredictorChol{T}(newZ, newZ, beta_j, ZZ_chol)
+        rss_j = sum(abs2, y_j .- mu_j)
+        tss_j = sum(abs2, y_j .- mean(y_j))
+        basis = trues(k_total)
+
+        fs_model = OLSMatrixEstimator{T, OLSPredictorChol{T}, typeof(vcov_type)}(
+            rr, pp, basis,
+            n, dof_fs, dof_residual_fs,
+            T(rss_j), T(tss_j), T(1 - rss_j / tss_j), true,
+            vcov_type, Symmetric(Matrix{T}(undef, k_total, k_total)),  # placeholder
+            Vector{T}(undef, k_total), Vector{T}(undef, k_total), Vector{T}(undef, k_total)
+        )
+
+        # Use CovarianceMatrices to compute vcov — handles all HC/HAC/CR/EWC types
+        vcov_matrix = try
+            CovarianceMatrices.vcov(vcov_type, fs_model)
+        catch
+            F_stats[j] = T(NaN)
+            p_values[j] = T(NaN)
+            continue
         end
 
-        # Compute meat of sandwich using pre-allocated buffer
-        _compute_meat_inplace!(meat_buf, M, vcov_type, nobs, k_total, dof_fes)
+        # Extract instrument coefficient block (last l × l)
+        vcov_pi = Symmetric(vcov_matrix[(k_exo + 1):end, (k_exo + 1):end])
+        pi_j = beta_j[(k_exo + 1):end]
 
-        # Full sandwich vcov: vcov_full = invZZ * meat * invZZ
-        # Use tmp_buf for intermediate result
-        mul!(tmp_buf, invZZ, meat_buf)
-        mul!(vcov_full, tmp_buf, invZZ)
-
-        # Extract instrument coefficient variances (last l × l block)
-        vcov_pi = @view vcov_full[(k_exo + 1):end, (k_exo + 1):end]
-        pi_j = @view coef_full_all[(k_exo + 1):end, j]
-
-        # Wald test: chi² = pi' * inv(V_pi) * pi
-        vcov_pi_chol = cholesky(Symmetric(vcov_pi); check = false)
+        # Wald test: F = (pi' * inv(V_pi) * pi) / l
+        vcov_pi_chol = cholesky(vcov_pi; check = false)
         if !issuccess(vcov_pi_chol)
             F_stats[j] = T(NaN)
             p_values[j] = T(NaN)
             continue
         end
 
-        # Copy pi_j to avoid issues with views in ldiv!
-        copyto!(pi_tmp, pi_j)
-        ldiv!(vcov_pi_chol, pi_tmp)
-        chi2 = dot(pi_j, pi_tmp)
+        chi2 = pi_j' * (vcov_pi_chol \ pi_j)
         F_j = chi2 / l
 
         F_stats[j] = F_j
@@ -525,54 +418,4 @@ function _compute_robust_first_stage_fstats_batched(
     end
 
     return F_stats, p_values
-end
-
-"""
-    _compute_meat_inplace!(dest, moment_matrix, vcov_type, nobs, dof_small, dof_fes)
-
-In-place version of _compute_meat that writes result to dest.
-"""
-function _compute_meat_inplace!(
-        dest::Matrix{T},
-        moment_matrix::Matrix{T},
-        vcov_type,
-        nobs::Int,
-        dof_small::Int,
-        dof_fes::Int
-) where {T <: AbstractFloat}
-    n = size(moment_matrix, 1)
-
-    if vcov_type isa CovarianceMatrices.HR0
-        # No adjustment: dest = M' * M
-        BLAS.syrk!('U', 'T', one(T), moment_matrix, zero(T), dest)
-        # Copy upper to lower
-        @inbounds for j in 1:size(dest, 2), i in (j + 1):size(dest, 1)
-
-            dest[i, j] = dest[j, i]
-        end
-    elseif vcov_type isa CovarianceMatrices.HR1
-        # HC1 adjustment
-        dof_residual = max(1, n - dof_small - dof_fes)
-        scale = T(n) / T(dof_residual)
-        BLAS.syrk!('U', 'T', scale, moment_matrix, zero(T), dest)
-        @inbounds for j in 1:size(dest, 2), i in (j + 1):size(dest, 1)
-
-            dest[i, j] = dest[j, i]
-        end
-    elseif vcov_type isa Union{CovarianceMatrices.CR0, CovarianceMatrices.CR1}
-        # Cluster-robust - fall back to allocating version for simplicity
-        meat = _compute_meat(moment_matrix, vcov_type, nobs, dof_small, dof_fes)
-        copyto!(dest, meat)
-    else
-        # Default: use HC1-like computation
-        dof_residual = max(1, n - dof_small - dof_fes)
-        scale = T(n) / T(dof_residual)
-        BLAS.syrk!('U', 'T', scale, moment_matrix, zero(T), dest)
-        @inbounds for j in 1:size(dest, 2), i in (j + 1):size(dest, 1)
-
-            dest[i, j] = dest[j, i]
-        end
-    end
-
-    return dest
 end

--- a/src/utils/weakiv_test.jl
+++ b/src/utils/weakiv_test.jl
@@ -51,7 +51,7 @@ critical values at various bias thresholds, and metadata.
 - `K::Int`: Number of excluded instruments
 - `N::Int`: Number of observations
 """
-struct WeakIVTestResult{T}
+struct WeakIVTestResult{T} <: AbstractTest
     # Test statistics
     F_eff::T
     F_nonrobust::T

--- a/test/test_formula.jl
+++ b/test/test_formula.jl
@@ -3,11 +3,21 @@
     using Regress
     using Regress: fe, parse_fixedeffect, _parse_fixedeffect, _multiply
     using FixedEffects
-    import Base: ==
 
-    function ==(x::FixedEffect, y::FixedEffect)
-        x.refs == y.refs && x.interaction == y.interaction && x.n == y.n
-    end
+    fe_eq(x::FixedEffect, y::FixedEffect) = x.refs == y.refs &&
+                                            x.interaction == y.interaction && x.n == y.n
+    fe_eq(a::Tuple, b::Tuple) = length(a) == length(b) &&
+                                all(fe_eq(ai, bi) for (ai, bi) in zip(a, b))
+    fe_eq(a::Vector{<:FixedEffect},
+        b::Vector{<:FixedEffect}) = length(a) == length(b) &&
+                                    all(fe_eq(ai, bi) for (ai, bi) in zip(a, b))
+    tup_eq(a::Tuple, b::Tuple) = length(a) == length(b) &&
+                                 all(_eq(ai, bi) for (ai, bi) in zip(a, b))
+    _eq(a, b) = a == b
+    _eq(a::FixedEffect, b::FixedEffect) = fe_eq(a, b)
+    _eq(a::Vector{<:FixedEffect}, b::Vector{<:FixedEffect}) = fe_eq(a, b)
+    _eq(a::Tuple, b::Tuple) = length(a) == length(b) &&
+                              all(_eq(ai, bi) for (ai, bi) in zip(a, b))
 
     csvfile = CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv"))
     df = DataFrame(csvfile)
@@ -16,8 +26,8 @@
     for data in [df, csvfile]
         @test _parse_fixedeffect(data, term(:Price)) === nothing
         @test _parse_fixedeffect(data, ConstantTerm(1)) === nothing
-        @test _parse_fixedeffect(data, fe(:State)) ==
-              (FixedEffect(data.State), :fe_State, [:State])
+        @test _eq(_parse_fixedeffect(data, fe(:State)),
+            (FixedEffect(data.State), :fe_State, [:State]))
 
         @test parse_fixedeffect(data, ()) == (FixedEffect[], Symbol[], Symbol[])
 
@@ -26,27 +36,27 @@
         ts2 = term(1) + term(:Price)
         @test parse_fixedeffect(data, f) == (FixedEffect[], Symbol[], Symbol[])
         @test parse_fixedeffect(data, ts1) == (FixedEffect[], Symbol[], Symbol[])
-        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+        @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
 
         f = @formula(y ~ 1 + Price + fe(State))
         ts1 = f.rhs
         ts2 = term(1) + term(:Price) + fe(:State)
-        @test parse_fixedeffect(data, f) ==
-              ([FixedEffect(data.State)], [:fe_State], [:State])
-        @test parse_fixedeffect(data, ts1) ==
-              ([FixedEffect(data.State)], [:fe_State], [:State])
-        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+        @test _eq(parse_fixedeffect(data, f),
+            ([FixedEffect(data.State)], [:fe_State], [:State]))
+        @test _eq(parse_fixedeffect(data, ts1),
+            ([FixedEffect(data.State)], [:fe_State], [:State]))
+        @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
 
         f = @formula(y ~ Price + fe(State) + fe(Year))
         ts1 = f.rhs
         ts2 = term(:Price) + fe(:State) + fe(:Year)
-        @test parse_fixedeffect(data, f) ==
-              ([FixedEffect(data.State), FixedEffect(data.Year)],
-            [:fe_State, :fe_Year], [:State, :Year])
-        @test parse_fixedeffect(data, ts1) ==
-              ([FixedEffect(data.State), FixedEffect(data.Year)],
-            [:fe_State, :fe_Year], [:State, :Year])
-        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+        @test _eq(parse_fixedeffect(data, f),
+            ([FixedEffect(data.State), FixedEffect(data.Year)],
+                [:fe_State, :fe_Year], [:State, :Year]))
+        @test _eq(parse_fixedeffect(data, ts1),
+            ([FixedEffect(data.State), FixedEffect(data.Year)],
+                [:fe_State, :fe_Year], [:State, :Year]))
+        @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
     end
 end
 
@@ -55,49 +65,57 @@ end
     using Regress
     using Regress: fe, parse_fixedeffect, _parse_fixedeffect, _multiply
     using FixedEffects
-    import Base: ==
 
-    function ==(x::FixedEffect, y::FixedEffect)
-        x.refs == y.refs && x.interaction == y.interaction && x.n == y.n
-    end
+    fe_eq(x::FixedEffect, y::FixedEffect) = x.refs == y.refs &&
+                                            x.interaction == y.interaction && x.n == y.n
+    _eq(a, b) = a == b
+    _eq(a::FixedEffect, b::FixedEffect) = fe_eq(a, b)
+    _eq(a::Vector{<:FixedEffect},
+        b::Vector{<:FixedEffect}) = length(a) == length(b) &&
+                                    all(fe_eq(ai, bi) for (ai, bi) in zip(a, b))
+    _eq(a::Tuple, b::Tuple) = length(a) == length(b) &&
+                              all(_eq(ai, bi) for (ai, bi) in zip(a, b))
 
     csvfile = CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv"))
     df = DataFrame(csvfile)
 
     # Any table type supporting the Tables.jl interface should work
     for data in [df, csvfile]
-        @test _parse_fixedeffect(data, fe(:State)&term(:Year)) ==
-              (FixedEffect(data.State, interaction = _multiply(data, [:Year])),
-            Symbol("fe_State&Year"), [:State])
-        @test _parse_fixedeffect(data, fe(:State)&fe(:Year)) ==
-              (
-            FixedEffect(data.State, data.Year), Symbol("fe_State&fe_Year"), [:State, :Year])
+        @test _eq(_parse_fixedeffect(data, fe(:State)&term(:Year)),
+            (FixedEffect(data.State, interaction = _multiply(data, [:Year])),
+                Symbol("fe_State&Year"), [:State]))
+        @test _eq(_parse_fixedeffect(data, fe(:State)&fe(:Year)),
+            (
+                FixedEffect(data.State, data.Year), Symbol("fe_State&fe_Year"), [
+                    :State, :Year]))
 
         f = @formula(y ~ Price + fe(State)&Year)
         ts1 = f.rhs
         ts2 = term(:Price) + fe(:State)&term(:Year)
-        @test parse_fixedeffect(data, f) ==
-              ([FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
-            [Symbol("fe_State&Year")], [:State])
-        @test parse_fixedeffect(data, ts1) ==
-              ([FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
-            [Symbol("fe_State&Year")], [:State])
-        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+        @test _eq(parse_fixedeffect(data, f),
+            ([FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
+                [Symbol("fe_State&Year")], [:State]))
+        @test _eq(parse_fixedeffect(data, ts1),
+            ([FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
+                [Symbol("fe_State&Year")], [:State]))
+        @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
 
         f = @formula(y ~ Price + fe(State)*fe(Year))
         ts1 = f.rhs
         ts2 = term(:Price) + fe(:State) + fe(:Year) + fe(:State)&fe(:Year)
-        @test parse_fixedeffect(data, f) == (
-            [
-                FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)],
-            [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")],
-            [:State, :Year])
-        @test parse_fixedeffect(data, ts1) == (
-            [
-                FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)],
-            [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")],
-            [:State, :Year])
-        @test parse_fixedeffect(data, ts2) == parse_fixedeffect(data, ts1)
+        @test _eq(parse_fixedeffect(data, f),
+            (
+                [
+                    FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)],
+                [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")],
+                [:State, :Year]))
+        @test _eq(parse_fixedeffect(data, ts1),
+            (
+                [
+                    FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)],
+                [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")],
+                [:State, :Year]))
+        @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
     end
 end
 
@@ -106,11 +124,16 @@ end
     using Regress
     using Regress: fe, parse_fixedeffect
     using FixedEffects
-    import Base: ==
 
-    function ==(x::FixedEffect, y::FixedEffect)
-        x.refs == y.refs && x.interaction == y.interaction && x.n == y.n
-    end
+    fe_eq(x::FixedEffect, y::FixedEffect) = x.refs == y.refs &&
+                                            x.interaction == y.interaction && x.n == y.n
+    _eq(a, b) = a == b
+    _eq(a::FixedEffect, b::FixedEffect) = fe_eq(a, b)
+    _eq(a::Vector{<:FixedEffect},
+        b::Vector{<:FixedEffect}) = length(a) == length(b) &&
+                                    all(fe_eq(ai, bi) for (ai, bi) in zip(a, b))
+    _eq(a::Tuple, b::Tuple) = length(a) == length(b) &&
+                              all(_eq(ai, bi) for (ai, bi) in zip(a, b))
 
     csvfile = CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv"))
     df = DataFrame(csvfile)
@@ -120,5 +143,160 @@ end
     result_df = parse_fixedeffect(df, f)
     result_csv = parse_fixedeffect(csvfile, f)
 
-    @test result_df == result_csv
+    @test _eq(result_df, result_csv)
+end
+
+@testitem "lags - numerical correctness" tags = [:formula, :lags] begin
+    using DataFrames, LinearAlgebra
+    using Regress
+    using StableRNGs
+
+    rng = StableRNG(42)
+    n = 100
+    x = randn(rng, n)
+    y = randn(rng, n)
+    df = DataFrame(y = y, x = x)
+
+    # --- Test 1: lags(x, 3) matches manual X\y ---
+    nlags = 3
+    # Valid rows: nlags+1 to n (rows where all lags are available)
+    valid = (nlags + 1):n
+    X_manual = hcat(ones(length(valid)),
+        x[valid .- 1],
+        x[valid .- 2],
+        x[valid .- 3])
+    beta_manual = X_manual \ y[valid]
+
+    m = Regress.ols(df, @formula(y ~ lags(x, 3)))
+    @test coef(m) ≈ beta_manual
+    @test nobs(m) == length(valid)
+
+    # --- Test 2: lags(log(y), 3) — transform then lag ---
+    ypos = exp.(randn(rng, n))  # positive values for log
+    w = randn(rng, n)
+    df2 = DataFrame(w = w, ypos = ypos)
+
+    logy = log.(ypos)
+    X_manual2 = hcat(ones(length(valid)),
+        logy[valid .- 1],
+        logy[valid .- 2],
+        logy[valid .- 3])
+    beta_manual2 = X_manual2 \ w[valid]
+
+    m2 = Regress.ols(df2, @formula(w ~ lags(log(ypos), 3)))
+    @test coef(m2) ≈ beta_manual2
+    @test nobs(m2) == length(valid)
+
+    # --- Test 3: coefficient names ---
+    cn = coefnames(m)
+    @test cn[1] == "(Intercept)"
+    @test cn[2] == "x_lag1"
+    @test cn[3] == "x_lag2"
+    @test cn[4] == "x_lag3"
+
+    # --- Test 4: combined with other terms ---
+    z = randn(rng, n)
+    df3 = DataFrame(y = y, x = x, z = z)
+    m3 = Regress.ols(df3, @formula(y ~ z + lags(x, 2)))
+    @test length(coef(m3)) == 4  # intercept + z + 2 lags
+
+    # Verify against manual
+    valid2 = 3:n
+    X_manual3 = hcat(ones(length(valid2)),
+        z[valid2],
+        x[valid2 .- 1],
+        x[valid2 .- 2])
+    beta_manual3 = X_manual3 \ y[valid2]
+    @test coef(m3) ≈ beta_manual3
+
+    # --- Test 5: lags with nested transforms combined with other function terms ---
+    # Regression test: lags(log(abs(x)), 3) + log(x) must not error
+    xpos = abs.(x) .+ 0.1
+    df5 = DataFrame(y = y, xpos = xpos)
+    m5 = Regress.ols(df5, @formula(y ~ lags(log(abs(xpos)), 3) + log(xpos)))
+    @test length(coef(m5)) == 5  # intercept + 3 lags + log(xpos)
+
+    logabsx = log.(abs.(xpos))
+    valid5 = (nlags + 1):n
+    X_manual5 = hcat(ones(length(valid5)),
+        logabsx[valid5 .- 1],
+        logabsx[valid5 .- 2],
+        logabsx[valid5 .- 3],
+        log.(xpos[valid5]))
+    beta_manual5 = X_manual5 \ y[valid5]
+    @test coef(m5) ≈ beta_manual5
+
+    # Verify coefficient names for nested transforms
+    cn5 = coefnames(m5)
+    @test cn5[2] == "log(abs(xpos))_lag1"
+    @test cn5[3] == "log(abs(xpos))_lag2"
+    @test cn5[4] == "log(abs(xpos))_lag3"
+end
+
+@testitem "lags - esample correctness" tags = [:formula, :lags] begin
+    using DataFrames
+    using Regress
+    using StableRNGs
+
+    rng = StableRNG(99)
+    n = 20
+
+    # --- Test 1: basic esample with lags ---
+    df1 = DataFrame(x = randn(rng, n), y = randn(rng, n))
+    m1 = Regress.ols(df1, @formula(y ~ lags(x, 2)))
+    @test sum(m1.esample) == nobs(m1) == n - 2
+    # First 2 rows should be false (NaN from lags), rest true
+    @test m1.esample[1:2] == [false, false]
+    @test all(m1.esample[3:n])
+
+    # --- Test 2: missing at start + NaN from lags ---
+    # Row 1 removed by completecases. Subsetted data is rows 2:n (19 rows).
+    # lags(x,2) → NaN in first 2 rows of subsetted data → original rows 2,3.
+    y2 = Vector{Union{Float64, Missing}}(randn(rng, n))
+    y2[1] = missing  # row 1: missing
+    df2 = DataFrame(x = randn(rng, n), y = y2)
+    m2 = Regress.ols(df2, @formula(y ~ lags(x, 2)))
+    @test m2.esample[1] == false   # missing
+    @test m2.esample[2] == false   # NaN from lag (1st row of subsetted data)
+    @test m2.esample[3] == false   # NaN from lag (2nd row of subsetted data)
+    @test all(m2.esample[4:n])
+    @test sum(m2.esample) == nobs(m2) == n - 3
+
+    # --- Test 3: missing in y and x in the middle ---
+    y3 = Vector{Union{Float64, Missing}}(randn(rng, n))
+    x3 = Vector{Union{Float64, Missing}}(randn(rng, n))
+    y3[10] = missing   # missing y at row 10
+    x3[12] = missing   # missing x at row 12
+    df3 = DataFrame(x = x3, y = y3)
+    m3 = Regress.ols(df3, @formula(y ~ lags(x, 2)))
+    @test m3.esample[1:2] == [false, false]  # NaN from lags
+    @test m3.esample[10] == false             # missing y
+    @test m3.esample[12] == false             # missing x
+    @test sum(m3.esample) == nobs(m3) == n - 4
+
+    # --- Test 4: missing at end ---
+    y4 = Vector{Union{Float64, Missing}}(randn(rng, n))
+    y4[n] = missing
+    df4 = DataFrame(x = randn(rng, n), y = y4)
+    m4 = Regress.ols(df4, @formula(y ~ lags(x, 2)))
+    @test m4.esample[1:2] == [false, false]   # NaN from lags
+    @test m4.esample[n] == false               # missing
+    @test all(m4.esample[3:(n - 1)])
+    @test sum(m4.esample) == nobs(m4) == n - 3
+
+    # --- Test 5: NaN in y at start and end (not missing) ---
+    df5 = DataFrame(x = randn(rng, n), y = [NaN; NaN; NaN; randn(rng, n - 4); NaN])
+    m5 = Regress.ols(df5, @formula(y ~ x + lags(x, 2)))
+    @test m5.esample[1:3] == [false, false, false]  # NaN y + NaN lags
+    @test m5.esample[n] == false                      # NaN y at end
+    @test sum(m5.esample) == nobs(m5) == n - 4
+
+    # --- Test 6: residuals alignment via esample ---
+    df6 = DataFrame(x = randn(rng, n), y = randn(rng, n))
+    m6 = Regress.ols(df6, @formula(y ~ lags(x, 3)))
+    res_full = fill(NaN, n)
+    res_full[m6.esample] .= residuals(m6)
+    @test all(!isnan, res_full[m6.esample])
+    @test all(isnan, res_full[.!m6.esample])
+    @test length(residuals(m6)) == sum(m6.esample)
 end

--- a/test/test_validation_fixest.jl
+++ b/test/test_validation_fixest.jl
@@ -18,7 +18,7 @@
     using Regress
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
@@ -71,7 +71,7 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
@@ -122,7 +122,7 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
@@ -172,20 +172,20 @@ end
     using Regress
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: (Intercept), x1, x2, fit_endo
     COEF = [1.426078709850737, 0.5022110369396626, 0.31777225217776084, 2.0533383199942645]
     R2 = 0.7970527457662797
-    F_KP = 135.55368890700018
+    F_IID = 290.9503015727274
 
     # Standard errors by vcov type
     # Note: HC1 SE computed with DOF convention that counts intercept (dof_res = n - k)
@@ -211,8 +211,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -233,20 +233,20 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: x1, x2, fit_endo (no intercept with FE)
     COEF = [0.517192834221396, 0.3000057923783143, 2.0316203354076725]
     R2 = 0.832384325466159
-    F_KP = 145.51765918382873
+    F_IID = 320.60480351691064
 
     # Standard errors by vcov type
     SE_HC1 = [0.06077896542330189, 0.04991147808908014, 0.07880872705581633]
@@ -269,8 +269,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -294,20 +294,20 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: x1, x2, fit_endo (no intercept with FE)
     COEF = [0.5061660563758806, 0.30523155864404355, 2.0222299546040468]
     R2 = 0.9216172253226353
-    F_KP = 145.19326049090716
+    F_IID = 316.4247374994751
 
     # Standard errors by vcov type
     SE_HC1 = [0.04297204886952502, 0.035058367355121675, 0.056918952667222356]
@@ -331,8 +331,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -356,20 +356,20 @@ end
     using Regress
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: (Intercept), x1, x2, fit_endo
     COEF = [1.4449688608098197, 0.5111036193727284, 0.3184713859664605, 2.028561669636886]
     R2 = 0.7946588621680999
-    F_KP = 24.35925856663632
+    F_IID = 30.067717609367953
 
     # Standard errors by vcov type
     # Note: HC1 SE computed with DOF convention that counts intercept (dof_res = n - k)
@@ -395,8 +395,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -416,20 +416,20 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: x1, x2, fit_endo (no intercept with FE)
     COEF = [0.5206045994953721, 0.3001680802913261, 2.0223390331838935]
     R2 = 0.8318476170503317
-    F_KP = 25.903487111101313
+    F_IID = 33.01547709081618
 
     # Standard errors by vcov type
     SE_HC1 = [0.06956941203475926, 0.04977094038737541, 0.11884473120651287]
@@ -451,8 +451,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -475,20 +475,20 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: x1, x2, fit_endo (no intercept with FE)
     COEF = [0.47887536778475115, 0.3035932600900931, 2.0960967017271352]
     R2 = 0.9258190793878247
-    F_KP = 24.896281475208674
+    F_IID = 32.06047455139025
 
     # Standard errors by vcov type
     SE_HC1 = [0.047837964392560675, 0.034156247365691846, 0.08042873148888426]
@@ -512,8 +512,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -536,20 +536,20 @@ end
     using Regress
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: (Intercept), x1, x2, fit_endo
     COEF = [1.4304839335133355, 0.5042848062091939, 0.3179352916746909, 2.0475603520642744]
     R2 = 0.7965074141689706
-    F_KP = 41.46776399951962
+    F_IID = 103.8605561494657
 
     # Standard errors by vcov type
     # Note: HC1 SE computed with DOF convention that counts intercept (dof_res = n - k)
@@ -576,8 +576,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -601,20 +601,20 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: x1, x2, fit_endo (no intercept with FE)
     COEF = [0.5166978714883292, 0.2999822484171923, 2.0329668227378943]
     R2 = 0.8324606828041137
-    F_KP = 43.486936945756945
+    F_IID = 119.21439932462302
 
     # Standard errors by vcov type
     SE_HC1 = [0.058224459538328215, 0.04982056618001574, 0.06147995587425259]
@@ -638,8 +638,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC
@@ -662,20 +662,20 @@ end
     using Regress: fe
     using DataFrames, CSV, CategoricalArrays
     using StatsBase: coef, stderror, r2
-    using CovarianceMatrices: HC1, CR1
+    using Regress: HC1, CR1
 
     # Tolerances
     RTOL_COEF = 1e-6
     RTOL_SE_HC = 1e-6
     RTOL_SE_CLUSTER = 1e-6
     RTOL_R2 = 1e-6
-    RTOL_F_KP = 1e-6
+    RTOL_F_IID = 1e-6
 
     # ----- Reference values from R fixest -----
     # Coefficients: x1, x2, fit_endo (no intercept with FE)
     COEF = [0.4965363222169623, 0.3046534721111661, 2.0482944174190525]
     R2 = 0.9232298394541512
-    F_KP = 43.43219369557059
+    F_IID = 117.34077475155085
 
     # Standard errors by vcov type
     SE_HC1 = [0.04085757225868013, 0.034699376630850265, 0.044274945728549696]
@@ -700,8 +700,8 @@ end
     # R-squared
     @test r2(m) ≈ R2 rtol = RTOL_R2
 
-    # First-stage F-statistic (Kleibergen-Paap)
-    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_KP rtol = RTOL_F_KP
+    # First-stage F-statistic (IID)
+    @test Regress.first_stage(m).F_nonrobust[1] ≈ F_IID rtol = RTOL_F_IID
 
     # Standard errors - HC1
     @test stderror(HC1(), m) ≈ SE_HC1 rtol = RTOL_SE_HC

--- a/test/test_vcov_operator.jl
+++ b/test/test_vcov_operator.jl
@@ -1,6 +1,6 @@
 @testitem "OLS + vcov(HC)" tags = [:ols, :vcov, :hc, :smoke] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: HC0, HC1, HC2, HC3
+    using Regress: HC0, HC1, HC2, HC3
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
     df.StateC = categorical(df.State)
@@ -24,7 +24,7 @@ end
 @testitem "OLS + vcov(HC) with FE" tags = [:ols, :vcov, :hc, :fe] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
     using Regress: fe
-    using CovarianceMatrices: HC0, HC1, HC2, HC3
+    using Regress: HC0, HC1, HC2, HC3
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
     df.StateC = categorical(df.State)
@@ -46,7 +46,7 @@ end
 
 @testitem "OLS + vcov(CR)" tags = [:ols, :vcov, :cluster] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: CR0, CR1, CR2, CR3
+    using Regress: CR0, CR1, CR2, CR3
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
     df.StateC = categorical(df.State)
@@ -80,7 +80,7 @@ end
 
 @testitem "OLS + vcov(HAC)" tags = [:ols, :vcov] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: Bartlett
+    using Regress: Bartlett
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
 
@@ -99,7 +99,7 @@ end
 
 @testitem "IV + vcov(HC)" tags = [:iv, :vcov, :hc] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: HC0, HC1, HC2
+    using Regress: HC0, HC1, HC2
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
     df.StateC = categorical(df.State)
@@ -122,7 +122,7 @@ end
 
 @testitem "IV + vcov(CR)" tags = [:iv, :vcov, :cluster] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: CR0, CR1
+    using Regress: CR0, CR1
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
     df.StateC = categorical(df.State)
@@ -147,7 +147,7 @@ end
 @testitem "IV + vcov(HC) with FE" tags = [:iv, :vcov, :hc, :fe] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
     using Regress: fe
-    using CovarianceMatrices: HC0, HC1
+    using Regress: HC0, HC1
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
     df.StateC = categorical(df.State)
@@ -169,7 +169,7 @@ end
 
 @testitem "IV + vcov(HAC)" tags = [:iv, :vcov] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: Bartlett
+    using Regress: Bartlett
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
 
@@ -188,7 +188,7 @@ end
 
 @testitem "vcov chaining" tags = [:vcov, :smoke] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: HC1, HC3
+    using Regress: HC1, HC3
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
 
@@ -207,7 +207,7 @@ end
 
 @testitem "StatsAPI methods" tags = [:vcov, :smoke] begin
     using Regress, CategoricalArrays, CSV, DataFrames, LinearAlgebra, StatsBase
-    using CovarianceMatrices: HC3
+    using Regress: HC3
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
 
@@ -243,7 +243,7 @@ end
 
 @testitem "first_stage with vcov" tags = [:iv, :vcov] begin
     using Regress, CategoricalArrays, CSV, DataFrames
-    using CovarianceMatrices: HC3
+    using Regress: HC3
 
     df = DataFrame(CSV.File(joinpath(dirname(pathof(Regress)), "../dataset/Cigar.csv")))
 


### PR DESCRIPTION
### New Features

- `@formula(y ~ lags(x, p))` expands into a matrix of p lag columns. Supports nested transforms (`lags(log(abs(x)), 3)`), interactions (`lags(x, 3) & z`), and composition with other terms. Moved from LocalProjections.jl so both packages share the same implementation.

- **`Homoskedastic` type**: Sentinel type used as the variance estimator parameter for IID F-tests.

- New first-stage diagnostic API returning `FirstStageFTest{T, K}` — parametric on value type (`Float64` or `Vector{Float64}`) and variance estimator type. Replaces the ambiguous `first_stage(m)` / `first_stage_f(m)` functions. `AbstractTest` is the new abstract supertype for `FirstStageFTest{T, K}` and `WeakIVTestResult{T}`.

- The joint KP test statistic is now stored on the model and accessible via `first_stage_F_KP(m)`. Previously computed but discarded.

- Rows with NaN values produced by `lags()` in the design matrix are automatically excluded from estimation in OLS, TSLS, and K-class models. The `esample` field correctly reflects these exclusions.

- All `Correlated` variance estimators from CovarianceMatrices.jl now work with `model + vcov(...)` (previously only `HAC` was supported).

### Bug Fixes

- The robust first-stage F with HC3 (and HC2/HC4/HC5) was silently using the HC1 formula. Refactored to delegate to CovarianceMatrices.jl, which handles all variance types correctly.

- `esample` now correctly marks NaN-filtered rows as `false`, so `sum(m.esample) == nobs(m)` and residuals can be mapped back to the original DataFrame via `res[m.esample] .= residuals(m)`.

- `@formula(y ~ lags(log(abs(x)), 3) + log(x))` previously crashed because `StatsModels.terms(::LagTerm)` returned a `FunctionTerm` instead of leaf terms.

- **`lags()` coefficient names for nested transforms**: `lags(log(abs(x)), 3)` produced names like `l_lag1` instead of `log(abs(x))_lag1`.

- The Kleibergen-Paap rank test's cluster-robust meat computation treated a `Clustering` struct as a raw vector. Fixed to use `.groups` / `.ngroups`.

- Test reference values for `F_nonrobust` were Kleibergen-Paap statistics, not IID F-statistics. Corrected to match the actual SSR-based F-test.

- HC1 and HC3 first-stage robust F-statistics were identical due to the HC3 fallthrough bug.

- The fallback when `Xendo_orig` is `nothing` passed `Z_res` as the full design matrix, producing wrong F-statistics. Replaced with an explicit error.

### Refactoring

- Replaced ~250 lines of manual sandwich variance computation (`_compute_meat_inplace!`, `_compute_robust_first_stage_fstats_batched`, `_compute_single_first_stage_fstat`) with `_compute_first_stage_fstats_via_ols`, which constructs lightweight `OLSMatrixEstimator` wrappers around pre-computed first-stage data and delegates to `CovarianceMatrices.vcov`. No refitting; ZZ factorization is shared across endogenous variables.

- Extracted the NaN-filtering logic (previously triplicated in `fit_ols.jl`, `tsls.jl`, `kclass.jl`) into a single function in `fit_common.jl`.

- `modelcols(::LagTerm)` now throws `ArgumentError` for multi-column inner terms (interactions, categoricals) instead of producing silently wrong results.

- `first_stage` and `weakivtest` in LocalProjections.jl now extend the Regress.jl functions instead of defining separate ones.

- Replaced `using CovarianceMatrices: ...` with `using Regress: ...` in test files where CovarianceMatrices is not directly loadable. Eliminated `Base.==` method redefinition warnings in `test_formula.jl`.

### Documentation

- `docs/src/iv_fstats.md`: New document covering all IV diagnostics — IID F, robust Wald F, Kleibergen-Paap rank test, Montiel-Olea-Pflueger weak IV test, Wu-Hausman endogeneity test, and Sargan overidentification test — with exact formulas, computation steps, and API examples.
