### PR TITLE
Fix `lags(x, n)` in @formula when `n` is a variable

### DIFF
--- a/src/utils/formula.jl
+++ b/src/utils/formula.jl
@@ -318,6 +318,17 @@ end
 
 Create multiple lag columns from 1 to n. Used in formulas like
 `@formula(y ~ lags(x, 5))` to create a matrix with lag(x,1), ..., lag(x,5).
+
+The lag count `n` may be supplied as an integer literal or as a binding
+defined at top level (`Main`), e.g.
+
+    j = 3
+    ols(df, @formula(y ~ lags(x, j)))      # uses j == 3
+    ols(df, @formula(y ~ lags(x, j + 1)))  # uses 4
+
+Bindings defined inside a `let`/function scope are not visible to the
+formula machinery; assign them at top level (or interpolate via a wrapper
+that constructs the term directly with `term(:x)`) when looping.
 """
 lags(t::T, n::Int) where {T <: AbstractTerm} = LagTerm{T}(t, n)
 
@@ -327,6 +338,9 @@ struct LagTerm{T <: AbstractTerm} <: AbstractTerm
 end
 
 StatsModels.terms(t::LagTerm) = StatsModels.terms(t.term)
+function StatsModels.terms(t::FunctionTerm{typeof(lags)})
+    length(t.args) >= 1 ? StatsModels.terms(t.args[1]) : AbstractTerm[]
+end
 StatsModels.needs_schema(::LagTerm) = false
 
 function _parse_lags_args(t::FunctionTerm)
@@ -334,12 +348,41 @@ function _parse_lags_args(t::FunctionTerm)
         return (first(t.args), 1)
     elseif length(t.args) == 2
         term, param_arg = t.args
-        (param_arg isa ConstantTerm) ||
-            throw(ArgumentError("lags parameter must be a number (got $param_arg)"))
-        return (term, param_arg.n)
+        if param_arg isa ConstantTerm
+            return (term, param_arg.n)
+        else
+            # The user passed something that `@formula` did not fold into a
+            # constant — e.g., `lags(x, j)` or `lags(x, j+1)` where `j` is
+            # bound in the calling scope. `@formula` rewrites such symbols
+            # into `Term`/`FunctionTerm` nodes, so resolve the original
+            # expression captured in `exorig` against `Main`.
+            n = _resolve_lag_count(t, param_arg)
+            return (term, n)
+        end
     else
         throw(ArgumentError("lags() requires 1 or 2 arguments"))
     end
+end
+
+function _resolve_lag_count(t::FunctionTerm, param)
+    expr = t.exorig
+    if !(expr isa Expr && expr.head === :call && length(expr.args) >= 3)
+        throw(ArgumentError(
+            "lags parameter must be a number or evaluate to one; got $(param)"))
+    end
+    arg_expr = expr.args[3]
+    val = try
+        Base.eval(Main, arg_expr)
+    catch err
+        throw(ArgumentError(
+            "lags() second argument `$(arg_expr)` could not be resolved " *
+            "from Main: $(sprint(showerror, err)). Pass an integer literal " *
+            "or define the variable at top level."))
+    end
+    val isa Integer ||
+        throw(ArgumentError("lags() second argument must evaluate to an " *
+                            "integer; got $(typeof(val))"))
+    return Int(val)
 end
 
 function _termvars_lags(t::FunctionTerm)

--- a/test/test_formula.jl
+++ b/test/test_formula.jl
@@ -300,3 +300,41 @@ end
     @test all(isnan, res_full[.!m6.esample])
     @test length(residuals(m6)) == sum(m6.esample)
 end
+
+@testitem "lags - dynamic lag count from variable" tags = [:formula, :lags] begin
+    using DataFrames
+    using Regress
+    using StableRNGs
+    using StatsModels: @formula
+
+    # GitHub issue #12: `lags(r, j)` where `j` is bound at top level.
+    # `@formula` rewrites a free symbol into a `Term`, so the count is
+    # resolved by evaluating the original expression in `Main`.
+    Core.eval(Main, :(using DataFrames, Regress, StableRNGs))
+    Core.eval(Main, :(using StatsModels: @formula))
+    Core.eval(Main, quote
+        rng_top = StableRNG(2026)
+        df_top = DataFrame(r = randn(rng_top, 60))
+        j_top = 3
+        m_var = Regress.ols(df_top, @formula(r ~ Regress.lags(r, j_top)))
+    end)
+    @test length(Core.eval(Main, :(coef(m_var)))) == 4
+
+    Core.eval(Main, quote
+        results = Int[]
+        for k in (2, 4, 6)
+            global j_top = k
+            m_loop = Regress.ols(df_top,
+                @formula(r ~ Regress.lags(r, j_top)))
+            push!(results, length(coef(m_loop)) - 1)
+        end
+    end)
+    @test Core.eval(Main, :results) == [2, 4, 6]
+
+    Core.eval(Main, quote
+        maxlag_top = 4
+        m_arith = Regress.ols(df_top,
+            @formula(r ~ Regress.lags(r, maxlag_top + 1)))
+    end)
+    @test length(Core.eval(Main, :(coef(m_arith)))) == 6
+end

--- a/test/test_formula.jl
+++ b/test/test_formula.jl
@@ -350,7 +350,6 @@ end
     # `@formula` rewrites a free symbol into a `Term`, so the count is
     # resolved by evaluating the original expression in `Main`.
     Core.eval(Main, :(using DataFrames, Regress, StableRNGs))
-    Core.eval(Main, :(using StatsModels: @formula))
     Core.eval(Main, quote
         rng_top = StableRNG(2026)
         df_top = DataFrame(r = randn(rng_top, 60))

--- a/test/test_formula.jl
+++ b/test/test_formula.jl
@@ -26,8 +26,10 @@
     for data in [df, csvfile]
         @test _parse_fixedeffect(data, term(:Price)) === nothing
         @test _parse_fixedeffect(data, ConstantTerm(1)) === nothing
-        @test _eq(_parse_fixedeffect(data, fe(:State)),
-            (FixedEffect(data.State), :fe_State, [:State]))
+        @test _eq(
+            _parse_fixedeffect(data, fe(:State)),
+            (FixedEffect(data.State), :fe_State, [:State])
+        )
 
         @test parse_fixedeffect(data, ()) == (FixedEffect[], Symbol[], Symbol[])
 
@@ -41,21 +43,35 @@
         f = @formula(y ~ 1 + Price + fe(State))
         ts1 = f.rhs
         ts2 = term(1) + term(:Price) + fe(:State)
-        @test _eq(parse_fixedeffect(data, f),
-            ([FixedEffect(data.State)], [:fe_State], [:State]))
-        @test _eq(parse_fixedeffect(data, ts1),
-            ([FixedEffect(data.State)], [:fe_State], [:State]))
+        @test _eq(
+            parse_fixedeffect(data, f),
+            ([FixedEffect(data.State)], [:fe_State], [:State])
+        )
+        @test _eq(
+            parse_fixedeffect(data, ts1),
+            ([FixedEffect(data.State)], [:fe_State], [:State])
+        )
         @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
 
         f = @formula(y ~ Price + fe(State) + fe(Year))
         ts1 = f.rhs
         ts2 = term(:Price) + fe(:State) + fe(:Year)
-        @test _eq(parse_fixedeffect(data, f),
-            ([FixedEffect(data.State), FixedEffect(data.Year)],
-                [:fe_State, :fe_Year], [:State, :Year]))
-        @test _eq(parse_fixedeffect(data, ts1),
-            ([FixedEffect(data.State), FixedEffect(data.Year)],
-                [:fe_State, :fe_Year], [:State, :Year]))
+        @test _eq(
+            parse_fixedeffect(data, f),
+            (
+                [FixedEffect(data.State), FixedEffect(data.Year)],
+                [:fe_State, :fe_Year],
+                [:State, :Year]
+            )
+        )
+        @test _eq(
+            parse_fixedeffect(data, ts1),
+            (
+                [FixedEffect(data.State), FixedEffect(data.Year)],
+                [:fe_State, :fe_Year],
+                [:State, :Year]
+            )
+        )
         @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
     end
 end
@@ -81,40 +97,71 @@ end
 
     # Any table type supporting the Tables.jl interface should work
     for data in [df, csvfile]
-        @test _eq(_parse_fixedeffect(data, fe(:State)&term(:Year)),
-            (FixedEffect(data.State, interaction = _multiply(data, [:Year])),
-                Symbol("fe_State&Year"), [:State]))
-        @test _eq(_parse_fixedeffect(data, fe(:State)&fe(:Year)),
+        @test _eq(
+            _parse_fixedeffect(data, fe(:State) & term(:Year)),
             (
-                FixedEffect(data.State, data.Year), Symbol("fe_State&fe_Year"), [
-                    :State, :Year]))
+                FixedEffect(data.State, interaction = _multiply(data, [:Year])),
+                Symbol("fe_State&Year"),
+                [:State]
+            )
+        )
+        @test _eq(
+            _parse_fixedeffect(data, fe(:State) & fe(:Year)),
+            (
+                FixedEffect(data.State, data.Year),
+                Symbol("fe_State&fe_Year"),
+                [:State, :Year]
+            )
+        )
 
-        f = @formula(y ~ Price + fe(State)&Year)
+        f = @formula(y ~ Price + fe(State) & Year)
         ts1 = f.rhs
-        ts2 = term(:Price) + fe(:State)&term(:Year)
-        @test _eq(parse_fixedeffect(data, f),
-            ([FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
-                [Symbol("fe_State&Year")], [:State]))
-        @test _eq(parse_fixedeffect(data, ts1),
-            ([FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
-                [Symbol("fe_State&Year")], [:State]))
+        ts2 = term(:Price) + fe(:State) & term(:Year)
+        @test _eq(
+            parse_fixedeffect(data, f),
+            (
+                [FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
+                [Symbol("fe_State&Year")],
+                [:State]
+            )
+        )
+        @test _eq(
+            parse_fixedeffect(data, ts1),
+            (
+                [FixedEffect(data.State, interaction = _multiply(data, [:Year]))],
+                [Symbol("fe_State&Year")],
+                [:State]
+            )
+        )
         @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
 
-        f = @formula(y ~ Price + fe(State)*fe(Year))
+        f = @formula(y ~ Price + fe(State) * fe(Year))
         ts1 = f.rhs
-        ts2 = term(:Price) + fe(:State) + fe(:Year) + fe(:State)&fe(:Year)
-        @test _eq(parse_fixedeffect(data, f),
+        ts2 = term(:Price) + fe(:State) + fe(:Year) + fe(:State) & fe(:Year)
+        @test _eq(
+            parse_fixedeffect(data, f),
             (
                 [
-                    FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)],
+                    FixedEffect(data.State),
+                    FixedEffect(data.Year),
+                    FixedEffect(data.State, data.Year)
+                ],
                 [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")],
-                [:State, :Year]))
-        @test _eq(parse_fixedeffect(data, ts1),
+                [:State, :Year]
+            )
+        )
+        @test _eq(
+            parse_fixedeffect(data, ts1),
             (
                 [
-                    FixedEffect(data.State), FixedEffect(data.Year), FixedEffect(data.State, data.Year)],
+                    FixedEffect(data.State),
+                    FixedEffect(data.Year),
+                    FixedEffect(data.State, data.Year)
+                ],
                 [:fe_State, :fe_Year, Symbol("fe_State&fe_Year")],
-                [:State, :Year]))
+                [:State, :Year]
+            )
+        )
         @test _eq(parse_fixedeffect(data, ts2), parse_fixedeffect(data, ts1))
     end
 end
@@ -161,10 +208,7 @@ end
     nlags = 3
     # Valid rows: nlags+1 to n (rows where all lags are available)
     valid = (nlags + 1):n
-    X_manual = hcat(ones(length(valid)),
-        x[valid .- 1],
-        x[valid .- 2],
-        x[valid .- 3])
+    X_manual = hcat(ones(length(valid)), x[valid .- 1], x[valid .- 2], x[valid .- 3])
     beta_manual = X_manual \ y[valid]
 
     m = Regress.ols(df, @formula(y ~ lags(x, 3)))
@@ -177,10 +221,7 @@ end
     df2 = DataFrame(w = w, ypos = ypos)
 
     logy = log.(ypos)
-    X_manual2 = hcat(ones(length(valid)),
-        logy[valid .- 1],
-        logy[valid .- 2],
-        logy[valid .- 3])
+    X_manual2 = hcat(ones(length(valid)), logy[valid .- 1], logy[valid .- 2], logy[valid .- 3])
     beta_manual2 = X_manual2 \ w[valid]
 
     m2 = Regress.ols(df2, @formula(w ~ lags(log(ypos), 3)))
@@ -202,10 +243,7 @@ end
 
     # Verify against manual
     valid2 = 3:n
-    X_manual3 = hcat(ones(length(valid2)),
-        z[valid2],
-        x[valid2 .- 1],
-        x[valid2 .- 2])
+    X_manual3 = hcat(ones(length(valid2)), z[valid2], x[valid2 .- 1], x[valid2 .- 2])
     beta_manual3 = X_manual3 \ y[valid2]
     @test coef(m3) ≈ beta_manual3
 
@@ -218,11 +256,13 @@ end
 
     logabsx = log.(abs.(xpos))
     valid5 = (nlags + 1):n
-    X_manual5 = hcat(ones(length(valid5)),
+    X_manual5 = hcat(
+        ones(length(valid5)),
         logabsx[valid5 .- 1],
         logabsx[valid5 .- 2],
         logabsx[valid5 .- 3],
-        log.(xpos[valid5]))
+        log.(xpos[valid5])
+    )
     beta_manual5 = X_manual5 \ y[valid5]
     @test coef(m5) ≈ beta_manual5
 
@@ -305,7 +345,6 @@ end
     using DataFrames
     using Regress
     using StableRNGs
-    using StatsModels: @formula
 
     # GitHub issue #12: `lags(r, j)` where `j` is bound at top level.
     # `@formula` rewrites a free symbol into a `Term`, so the count is
@@ -320,21 +359,25 @@ end
     end)
     @test length(Core.eval(Main, :(coef(m_var)))) == 4
 
-    Core.eval(Main, quote
-        results = Int[]
-        for k in (2, 4, 6)
-            global j_top = k
-            m_loop = Regress.ols(df_top,
-                @formula(r ~ Regress.lags(r, j_top)))
-            push!(results, length(coef(m_loop)) - 1)
+    Core.eval(
+        Main,
+        quote
+            results = Int[]
+            for k in (2, 4, 6)
+                global j_top = k
+                m_loop = Regress.ols(df_top, @formula(r ~ Regress.lags(r, j_top)))
+                push!(results, length(coef(m_loop)) - 1)
+            end
         end
-    end)
+    )
     @test Core.eval(Main, :results) == [2, 4, 6]
 
-    Core.eval(Main, quote
-        maxlag_top = 4
-        m_arith = Regress.ols(df_top,
-            @formula(r ~ Regress.lags(r, maxlag_top + 1)))
-    end)
+    Core.eval(
+        Main,
+        quote
+            maxlag_top = 4
+            m_arith = Regress.ols(df_top, @formula(r ~ Regress.lags(r, maxlag_top + 1)))
+        end
+    )
     @test length(Core.eval(Main, :(coef(m_arith)))) == 6
 end


### PR DESCRIPTION
@formula rewrites free symbols as `Term`s, so `lags(r, j)` failed with "no variable 'j' in your data" because `j` was treated as a data column.

- Override StatsModels.terms for FunctionTerm{typeof(lags)} to only expose the data term, keeping the count out of schema lookup.
- In _parse_lags_args, resolve non-ConstantTerm counts by evaluating the original expression (from FunctionTerm.exorig) in Main.

Supports `lags(x, j)`, `lags(x, j+1)`, and loops mutating `j`. The binding must live at top level; documented in the docstring.

Fix #12 