### PR TITLE
Revert the fix in #12

### DIFF
--- a/src/utils/formula.jl
+++ b/src/utils/formula.jl
@@ -319,16 +319,16 @@ end
 Create multiple lag columns from 1 to n. Used in formulas like
 `@formula(y ~ lags(x, 5))` to create a matrix with lag(x,1), ..., lag(x,5).
 
-The lag count `n` may be supplied as an integer literal or as a binding
-defined at top level (`Main`), e.g.
+Inside `@formula`, the second argument must be an integer literal —
+`@formula` rewrites free symbols as `Term` nodes representing data
+columns, so `lags(x, j)` cannot pick up `j` from the surrounding scope.
+To use a dynamic lag count (e.g. inside a loop), build the formula
+programmatically:
 
-    j = 3
-    ols(df, @formula(y ~ lags(x, j)))      # uses j == 3
-    ols(df, @formula(y ~ lags(x, j + 1)))  # uses 4
-
-Bindings defined inside a `let`/function scope are not visible to the
-formula machinery; assign them at top level (or interpolate via a wrapper
-that constructs the term directly with `term(:x)`) when looping.
+    for j in 1:4
+        f = term(:y) ~ term(1) + lags(term(:x), j)
+        ols(df, f)
+    end
 """
 lags(t::T, n::Int) where {T <: AbstractTerm} = LagTerm{T}(t, n)
 
@@ -351,38 +351,15 @@ function _parse_lags_args(t::FunctionTerm)
         if param_arg isa ConstantTerm
             return (term, param_arg.n)
         else
-            # The user passed something that `@formula` did not fold into a
-            # constant — e.g., `lags(x, j)` or `lags(x, j+1)` where `j` is
-            # bound in the calling scope. `@formula` rewrites such symbols
-            # into `Term`/`FunctionTerm` nodes, so resolve the original
-            # expression captured in `exorig` against `Main`.
-            n = _resolve_lag_count(t, param_arg)
-            return (term, n)
+            throw(ArgumentError(
+                "lags() inside @formula requires an integer literal as the " *
+                "second argument; got `$(t.exorig)`. To use a dynamic lag " *
+                "count, build the formula programmatically, e.g. " *
+                "`term(:y) ~ term(1) + lags(term(:x), j)`."))
         end
     else
         throw(ArgumentError("lags() requires 1 or 2 arguments"))
     end
-end
-
-function _resolve_lag_count(t::FunctionTerm, param)
-    expr = t.exorig
-    if !(expr isa Expr && expr.head === :call && length(expr.args) >= 3)
-        throw(ArgumentError(
-            "lags parameter must be a number or evaluate to one; got $(param)"))
-    end
-    arg_expr = expr.args[3]
-    val = try
-        Base.eval(Main, arg_expr)
-    catch err
-        throw(ArgumentError(
-            "lags() second argument `$(arg_expr)` could not be resolved " *
-            "from Main: $(sprint(showerror, err)). Pass an integer literal " *
-            "or define the variable at top level."))
-    end
-    val isa Integer ||
-        throw(ArgumentError("lags() second argument must evaluate to an " *
-                            "integer; got $(typeof(val))"))
-    return Int(val)
 end
 
 function _termvars_lags(t::FunctionTerm)

--- a/test/test_formula.jl
+++ b/test/test_formula.jl
@@ -341,42 +341,30 @@ end
     @test length(residuals(m6)) == sum(m6.esample)
 end
 
-@testitem "lags - dynamic lag count from variable" tags = [:formula, :lags] begin
+@testitem "lags - dynamic lag count via programmatic formula" tags = [:formula, :lags] begin
     using DataFrames
     using Regress
     using StableRNGs
+    using StatsModels: term
 
-    # GitHub issue #12: `lags(r, j)` where `j` is bound at top level.
-    # `@formula` rewrites a free symbol into a `Term`, so the count is
-    # resolved by evaluating the original expression in `Main`.
-    Core.eval(Main, :(using DataFrames, Regress, StableRNGs))
-    Core.eval(Main, quote
-        rng_top = StableRNG(2026)
-        df_top = DataFrame(r = randn(rng_top, 60))
-        j_top = 3
-        m_var = Regress.ols(df_top, @formula(r ~ Regress.lags(r, j_top)))
-    end)
-    @test length(Core.eval(Main, :(coef(m_var)))) == 4
+    rng = StableRNG(2026)
+    df = DataFrame(r = randn(rng, 60))
 
-    Core.eval(
-        Main,
-        quote
-            results = Int[]
-            for k in (2, 4, 6)
-                global j_top = k
-                m_loop = Regress.ols(df_top, @formula(r ~ Regress.lags(r, j_top)))
-                push!(results, length(coef(m_loop)) - 1)
-            end
-        end
-    )
-    @test Core.eval(Main, :results) == [2, 4, 6]
+    # GitHub issue #12: `@formula(r ~ lags(r, j))` cannot resolve a
+    # local `j` because `@formula` treats free symbols as data columns.
+    # The supported pattern is to build the formula programmatically.
+    results = Int[]
+    for j in (2, 4, 6)
+        f = term(:r) ~ term(1) + lags(term(:r), j)
+        m = Regress.ols(df, f)
+        push!(results, length(coef(m)) - 1)
+    end
+    @test results == [2, 4, 6]
 
-    Core.eval(
-        Main,
-        quote
-            maxlag_top = 4
-            m_arith = Regress.ols(df_top, @formula(r ~ Regress.lags(r, maxlag_top + 1)))
-        end
-    )
-    @test length(Core.eval(Main, :(coef(m_arith)))) == 6
+    # Inside @formula, an integer literal still works.
+    m_lit = Regress.ols(df, @formula(r ~ lags(r, 3)))
+    @test length(coef(m_lit)) == 4
+
+    # A non-literal lag count inside @formula now raises a clear error.
+    @test_throws ArgumentError Regress.ols(df, @formula(r ~ lags(r, j_local)))
 end

--- a/test/test_formula.jl
+++ b/test/test_formula.jl
@@ -345,7 +345,6 @@ end
     using DataFrames
     using Regress
     using StableRNGs
-    using StatsModels: term
 
     rng = StableRNG(2026)
     df = DataFrame(r = randn(rng, 60))


### PR DESCRIPTION
This revert the changes in #12. The way to properly deal with the issue of making the lags depend on a variable in the scope is to build the formula programmatically inside the scope. 

